### PR TITLE
Forleng frist modal

### DIFF
--- a/komponenter/src/BekreftelseModal/BekreftelseModal.tsx
+++ b/komponenter/src/BekreftelseModal/BekreftelseModal.tsx
@@ -23,17 +23,22 @@ const BekreftelseModal: FunctionComponent<Props & PropsWithChildren> = (props) =
                 className={cls.element('container')}
                 style={props.containerStyle}
             >
-                <Modal.Header>
-                    <Heading size="large" className={cls.element('tittel')}>
-                        {props.tittel}
-                    </Heading>
-                </Modal.Header>
-                <Modal.Body>{props.children}</Modal.Body>
-                <Modal.Footer>
-                    <LagreOgAvbrytKnapp lagreFunksjon={props.bekreft} avbryt={() => props.lukkModal()}>
-                        OK
-                    </LagreOgAvbrytKnapp>
-                </Modal.Footer>
+                {/* Rydder feilmeldinger fra api-kall i LagreOgAvbrytKnapp når modal lukkes */}
+                {props.isOpen && (
+                    <>
+                        <Modal.Header>
+                            <Heading size="large" className={cls.element('tittel')}>
+                                {props.tittel}
+                            </Heading>
+                        </Modal.Header>
+                        <Modal.Body>{props.children}</Modal.Body>
+                        <Modal.Footer>
+                            <LagreOgAvbrytKnapp lagreFunksjon={props.bekreft} avbryt={() => props.lukkModal()}>
+                                OK
+                            </LagreOgAvbrytKnapp>
+                        </Modal.Footer>
+                    </>
+                )}
             </Modal>
         </div>
     );

--- a/komponenter/src/types/refusjon.ts
+++ b/komponenter/src/types/refusjon.ts
@@ -26,6 +26,7 @@ export interface Refusjon {
     sistEndret: string;
     åpnetFørsteGang: string;
     harInntektIAlleMåneder: boolean;
+    senestMuligeGodkjenningsfrist: string;
 }
 
 export interface Korreksjon {

--- a/saksbehandler/src/refusjon/ForlengFrist/ForlengFrist.less
+++ b/saksbehandler/src/refusjon/ForlengFrist/ForlengFrist.less
@@ -1,12 +1,10 @@
 .forleng-frist {
-    &__container {
-        display: flex;
-        justify-content: center;
-        width: calc(100% - 1rem);
-        margin-bottom: 1.5rem;
-        flex-direction: column;
-        padding: 0 0.5rem;
-    }
+    display: flex;
+    justify-content: center;
+    width: calc(100% - 1rem);
+    margin-bottom: 1.5rem;
+    flex-direction: column;
+    padding: 0 0.5rem;
 
     &__input-wrapper {
         display: flex;
@@ -34,10 +32,6 @@
             margin-bottom: 0;
         }
     }
-    &__dato-velger {
-        display: flex;
-        justify-content: center;
-    }
 
     .DayPicker-Day {
         padding: 0.5rem 0.75rem;
@@ -45,14 +39,9 @@
     }
 
     @media (min-width: 768px) {
-        &__container {
-            padding: 0 0.5rem;
-            width: calc(100% - 1rem);
-            flex-direction: row;
-        }
-        &__dato-velger {
-            margin-right: 1rem;
-        }
+        padding: 0 0.5rem;
+        width: calc(100% - 1rem);
+        flex-direction: row;
 
         .DayPicker-Day {
             padding: 0.5rem 0.75rem;

--- a/saksbehandler/src/refusjon/ForlengFrist/ForlengFrist.tsx
+++ b/saksbehandler/src/refusjon/ForlengFrist/ForlengFrist.tsx
@@ -1,18 +1,19 @@
 import Calender from '@/asset/image/calender2.svg?react';
 import { Button, Label, TextField } from '@navikt/ds-react';
-import React, { FunctionComponent, useEffect, useState } from 'react';
+import { FunctionComponent, useState } from 'react';
 import { nb } from 'date-fns/locale';
 import { DayPicker } from 'react-day-picker';
 import 'react-day-picker/dist/style.css';
-import { useParams } from 'react-router';
 import BekreftelseModal from '~/BekreftelseModal';
-import { forlengFrist, useHentRefusjon } from '../../services/rest-service';
+import { forlengFrist } from '@/services/rest-service';
 import './ForlengFrist.less';
 import {
     finnFeilMeldingFraInputDialog,
     ForlengeDatoSkjemaGruppeFeil,
-    formatDateToIsoDateFormat,
-    getDateStringFraDatoVelger,
+    norskDatoTilISOString,
+    parseNorskDato,
+    erGyldigDato,
+    datoTilNorskString,
 } from './forlengFristUtils';
 import GrunnlagTilForlengelse from './GrunnlagTilForlengelse';
 import { FeilkodeError } from '~/types/errors';
@@ -20,28 +21,22 @@ import BEMHelper from '~/utils/bem';
 
 const cls = BEMHelper('forleng-frist');
 
-const ForlengFrist: FunctionComponent = () => {
-    const { refusjonId } = useParams<{ refusjonId: string }>();
-    const refusjon = useHentRefusjon(refusjonId!);
-    const [open, setOpen] = useState<boolean>(false);
-    const [datoFraDatoVelger, setDatoFraDatoVelger] = useState<Date>(
-        new Date(Date.parse(refusjon.fristForGodkjenning))
-    );
-    const [datoFraInputFelt, setDatoFraInputFelt] = useState<string>(refusjon.fristForGodkjenning);
+const ForlengFristModalKropp: FunctionComponent<{
+    tidligsteFrist: string;
+    senesteFrist: string;
+    lukkModal: () => any;
+    oppdatereRefusjonFrist: (dato: string, grunnlag: string, annetGrunnlag: string) => any;
+}> = ({ tidligsteFrist, senesteFrist, oppdatereRefusjonFrist, lukkModal }) => {
+    const tidligsteFristDato = new Date(Date.parse(tidligsteFrist));
+    const senesteFristDato = new Date(Date.parse(senesteFrist));
+    const senesteFristNorskDatoStreng = datoTilNorskString(senesteFristDato);
+
+    const [month, setMonth] = useState<Date>(tidligsteFristDato);
+    const [datoFraDatoVelger, setDatoFraDatoVelger] = useState<Date>(tidligsteFristDato);
+    const [datoFraInputFelt, setDatoFraInputFelt] = useState<string>(datoTilNorskString(tidligsteFristDato));
     const [grunnlag, setGrunnlag] = useState<string>('');
     const [annetGrunnlag, setAnnetGrunnlag] = useState<string>('');
     const [skjemaGruppeFeilmeldinger, setSkjemaGruppeFeilmeldinger] = useState<ForlengeDatoSkjemaGruppeFeil[] | []>([]);
-
-    useEffect(() => {
-        setDatoFraInputFelt(getDateStringFraDatoVelger(datoFraDatoVelger));
-    }, [datoFraDatoVelger]);
-
-    const lukkModalOgResettState = () => {
-        setGrunnlag('');
-        setAnnetGrunnlag('');
-        setSkjemaGruppeFeilmeldinger([]);
-        setOpen(false);
-    };
 
     const setNyFeilMelding = (id: string, feilMelding: string) => {
         setSkjemaGruppeFeilmeldinger((prevState) => [...prevState, ...[{ id: id, feilMelding: feilMelding }]]);
@@ -50,105 +45,139 @@ const ForlengFrist: FunctionComponent = () => {
     const sjekkInnsendingsInformasjon = () => {
         let KAN_SENDE_INN: boolean = true;
         setSkjemaGruppeFeilmeldinger([]);
-        const parseDate = Date.parse(formatDateToIsoDateFormat(datoFraInputFelt));
-        if (isNaN(parseDate)) {
+        const parseDate = parseNorskDato(datoFraInputFelt);
+        if (isNaN(parseDate.getTime())) {
             setNyFeilMelding('ugyldig-datoformat', 'Ugyldig datoformat. DD.MM.YYYY.');
             KAN_SENDE_INN = false;
         }
-        if (new Date(parseDate) <= new Date(refusjon.fristForGodkjenning)) {
+        if (parseDate <= tidligsteFristDato) {
             setNyFeilMelding('for-kort-frist', 'Ny frist må være etter opprinnelig frist.');
+            KAN_SENDE_INN = false;
+        }
+        if (parseDate > senesteFristDato) {
+            setNyFeilMelding('for-lang-frist', `Frist kan ikke overstige ${senesteFristNorskDatoStreng}.`);
             KAN_SENDE_INN = false;
         }
         if (grunnlag.length === 0) {
             setNyFeilMelding('mangler-grunnlag', 'Må sette grunn til forlenglse.');
             KAN_SENDE_INN = false;
         }
-        if (grunnlag.includes('Annet') && annetGrunnlag.length === 0) {
+        if (grunnlag.includes('Annet') && annetGrunnlag.trim().length === 0) {
             setNyFeilMelding('mangler-annet', 'Mangler tekst for annet grunnlag.');
             KAN_SENDE_INN = false;
         }
         if (KAN_SENDE_INN) {
             setSkjemaGruppeFeilmeldinger([]);
-            return oppdatereRefusjonFrist();
+            return oppdatereRefusjonFrist(datoFraInputFelt, grunnlag, annetGrunnlag);
         } else {
             return Promise.reject(new FeilkodeError('Alle påkrevde felter må være utfylt'));
         }
     };
 
-    const oppdatereRefusjonFrist = async () => {
+    return (
+        <BekreftelseModal
+            isOpen={true}
+            lukkModal={lukkModal}
+            bekreft={sjekkInnsendingsInformasjon}
+            tittel={'Forleng refusjonsfrist'}
+            containerStyle={{ minWidth: 'unset' }}
+        >
+            <div className={cls.className}>
+                <DayPicker
+                    month={month}
+                    onMonthChange={setMonth}
+                    selected={datoFraDatoVelger}
+                    onDayClick={(day) => {
+                        setDatoFraInputFelt(datoTilNorskString(day));
+                        setDatoFraDatoVelger(day);
+                    }}
+                    locale={nb}
+                    disabled={{
+                        before: tidligsteFristDato,
+                        after: senesteFristDato,
+                    }}
+                />
+                <div className={cls.element('text-wrapper')}>
+                    <div className={cls.element('dato-input')}>
+                        <div className={cls.element('dato-label')}>
+                            <Calender width={20} height={20} />
+                            <Label className={cls.element('label')} htmlFor="dato-label">
+                                Dato
+                            </Label>
+                        </div>
+                        <div className={cls.element('input-wrapper')}>
+                            <TextField
+                                label=""
+                                hideLabel
+                                error={finnFeilMeldingFraInputDialog(
+                                    ['ugyldig-datoformat', 'for-kort-frist', 'for-lang-frist'],
+                                    skjemaGruppeFeilmeldinger
+                                )}
+                                onChange={(event) => {
+                                    const input = event.target.value;
+                                    const parsedDate = parseNorskDato(input);
+                                    if (erGyldigDato(parsedDate)) {
+                                        setDatoFraDatoVelger(parsedDate);
+                                        setMonth(parsedDate);
+                                    }
+                                    setDatoFraInputFelt(input);
+                                }}
+                                className={cls.element('input-felt-dato')}
+                                id="dato-input"
+                                size="small"
+                                value={datoFraInputFelt}
+                            />
+                        </div>
+                    </div>
+                    <GrunnlagTilForlengelse
+                        grunnlag={grunnlag}
+                        setGrunnlag={setGrunnlag}
+                        annetGrunnlag={annetGrunnlag}
+                        setAnnetGrunnlag={setAnnetGrunnlag}
+                        skjemaGruppeFeilmeldinger={skjemaGruppeFeilmeldinger}
+                    />
+                </div>
+            </div>
+        </BekreftelseModal>
+    );
+};
+
+const ForlengFrist: FunctionComponent<{ refusjonId: string; tidligsteFrist: string; senesteFrist: string }> = ({
+    refusjonId,
+    tidligsteFrist,
+    senesteFrist,
+}) => {
+    const [open, setOpen] = useState<boolean>(false);
+
+    const openModal = () => {
+        setOpen(true);
+    };
+    const lukkModal = () => {
+        setOpen(false);
+    };
+
+    const oppdatereRefusjonFrist = async (dato: string, grunnlag: string, annetGrunnlag: string) => {
         const valgGrunn = grunnlag.includes('Annet') ? annetGrunnlag : grunnlag;
         await forlengFrist(refusjonId!, {
-            nyFrist: formatDateToIsoDateFormat(datoFraInputFelt),
+            nyFrist: norskDatoTilISOString(dato),
             årsak: valgGrunn,
         });
-        lukkModalOgResettState();
+        setOpen(false);
     };
 
     return (
         <div>
-            <Button
-                size="small"
-                variant="secondary"
-                className={cls.element('openButton')}
-                onClick={() => setOpen(!open)}
-            >
+            <Button size="small" variant="secondary" className={cls.element('openButton')} onClick={() => openModal()}>
                 Forleng frist
             </Button>
-            <BekreftelseModal
-                isOpen={open}
-                lukkModal={lukkModalOgResettState}
-                bekreft={sjekkInnsendingsInformasjon}
-                tittel={'Forleng refusjonsfrist'}
-                containerStyle={{ minWidth: 'unset' }}
-            >
-                <div className={cls.className}>
-                    <div className={cls.element('container')}>
-                        <div className={cls.element('dato-velger')}>
-                            <DayPicker
-                                defaultMonth={datoFraDatoVelger}
-                                selected={datoFraDatoVelger}
-                                onDayClick={(day) => setDatoFraDatoVelger(day)}
-                                locale={nb}
-                                disabled={{
-                                    before: new Date(Date.parse(refusjon.fristForGodkjenning)),
-                                }}
-                            />
-                        </div>
-                        <div className={cls.element('text-wrapper')}>
-                            <div className={cls.element('dato-input')}>
-                                <div className={cls.element('dato-label')}>
-                                    <Calender width={20} height={20} />
-                                    <Label className={cls.element('label')} htmlFor="dato-label">
-                                        Dato
-                                    </Label>
-                                </div>
-                                <div className={cls.element('input-wrapper')}>
-                                    <TextField
-                                        label=""
-                                        hideLabel
-                                        error={finnFeilMeldingFraInputDialog(
-                                            ['ugyldig-datoformat', 'for-kort-frist', 'for-lang-frist'],
-                                            skjemaGruppeFeilmeldinger
-                                        )}
-                                        onChange={(event) => setDatoFraInputFelt(event.target.value)}
-                                        className={cls.element('input-felt-dato')}
-                                        id="dato-input"
-                                        size="small"
-                                        value={datoFraInputFelt}
-                                    />
-                                </div>
-                            </div>
-                            <GrunnlagTilForlengelse
-                                grunnlag={grunnlag}
-                                setGrunnlag={setGrunnlag}
-                                annetGrunnlag={annetGrunnlag}
-                                setAnnetGrunnlag={setAnnetGrunnlag}
-                                skjemaGruppeFeilmeldinger={skjemaGruppeFeilmeldinger}
-                            />
-                        </div>
-                    </div>
-                </div>
-            </BekreftelseModal>
+            {open && (
+                <ForlengFristModalKropp
+                    oppdatereRefusjonFrist={oppdatereRefusjonFrist}
+                    lukkModal={lukkModal}
+                    tidligsteFrist={tidligsteFrist}
+                    senesteFrist={senesteFrist}
+                />
+            )}
         </div>
     );
 };

--- a/saksbehandler/src/refusjon/ForlengFrist/GrunnlagTilForlengelse.tsx
+++ b/saksbehandler/src/refusjon/ForlengFrist/GrunnlagTilForlengelse.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FunctionComponent, SetStateAction } from 'react';
+import { Dispatch, FunctionComponent, SetStateAction } from 'react';
 import { ForlengeDatoSkjemaGruppeFeil, finnFeilMeldingFraInputDialog } from './forlengFristUtils';
 import { RadioGroup, Radio, Textarea, Fieldset } from '@navikt/ds-react';
 
@@ -12,27 +12,26 @@ interface Props {
 
 const GrunnlagTilForlengelse: FunctionComponent<Props> = (props) => {
     const { grunnlag, setGrunnlag, annetGrunnlag, setAnnetGrunnlag, skjemaGruppeFeilmeldinger } = props;
+
     return (
         <div>
             <Fieldset legend>
                 <RadioGroup
                     error={finnFeilMeldingFraInputDialog(['mangler-grunnlag'], skjemaGruppeFeilmeldinger)}
                     legend="Årsaker til forlengelse av refusjonsfristen?"
+                    value={grunnlag}
+                    onChange={setGrunnlag}
                 >
-                    <Radio value="" name="begrunnelse" onClick={() => setGrunnlag('Ikke-tilgang')}>
+                    <Radio value="Ikke-tilgang" name="begrunnelse">
                         Ikke tilgang
                     </Radio>
-                    <Radio value={true} name="begrunnelse" onClick={() => setGrunnlag('Finner ikke inntekt')}>
+                    <Radio value="Finner ikke inntekt" name="begrunnelse">
                         Finner ikke inntekt fra a-melding
                     </Radio>
-                    <Radio
-                        value={true}
-                        name="begrunnelse"
-                        onClick={() => setGrunnlag('Ikke mottatt SMS med lenke til refusjon og varsel')}
-                    >
+                    <Radio value="Ikke mottatt SMS med lenke til refusjon og varsel" name="begrunnelse">
                         Ikke mottatt SMS med lenke til refusjon og varsel
                     </Radio>
-                    <Radio value={true} name="begrunnelse" onClick={() => setGrunnlag('Annet')}>
+                    <Radio value="Annet" name="begrunnelse">
                         Annet
                     </Radio>
                 </RadioGroup>

--- a/saksbehandler/src/refusjon/ForlengFrist/forlengFristUtils.ts
+++ b/saksbehandler/src/refusjon/ForlengFrist/forlengFristUtils.ts
@@ -1,3 +1,5 @@
+import { format, parse } from 'date-fns';
+
 export interface ForlengeDatoSkjemaGruppeFeil {
     id: string;
     feilMelding: string;
@@ -27,22 +29,23 @@ export const disableAfter = (sisteFristDato: string, antallMnd: number): string 
         .join('-');
 };
 
-export const getDateStringFraDatoVelger = (datoFraDatoVelger: Date): string => {
-    return datoFraDatoVelger
-        .toLocaleDateString('no-No')
-        .split('.')
-        .map((d, i) => (d.length === 1 ? '0'.concat(d) : d))
-        .join('.');
+const datoTilISOString = (dato: Date): string => {
+    return format(dato, 'yyyy-MM-dd');
 };
 
-export const formatDateToIsoDateFormat = (date: string): string => {
-    const d = date
-        .split('.')
-        .map((d, i) => (d.length === 1 ? '0'.concat(d) : d))
-        .join('.')
-        .split('.');
-    return d.length === 3 ? d[2].concat('-').concat(d[1]).concat('-').concat(d[0]) : date;
+export const datoTilNorskString = (dato: Date): string => {
+    return format(dato, 'dd.MM.yyyy');
 };
+
+export const parseNorskDato = (date: string): Date => {
+    return parse(date, 'dd.MM.yyyy', new Date());
+};
+
+export const norskDatoTilISOString = (date: string): string => {
+    return datoTilISOString(parse(date, 'dd.MM.yyyy', new Date()));
+};
+
+export const erGyldigDato = (dato: Date) => !isNaN(dato.getTime());
 
 export const finnFeilMeldingFraInputDialog = (
     id: string[],

--- a/saksbehandler/src/refusjon/RefusjonSide/Refusjon.tsx
+++ b/saksbehandler/src/refusjon/RefusjonSide/Refusjon.tsx
@@ -110,7 +110,11 @@ const Komponent: FunctionComponent = () => {
             return (
                 <>
                     <Fleks>
-                        <ForlengFrist />
+                        <ForlengFrist
+                            refusjonId={refusjon.id}
+                            tidligsteFrist={refusjon.fristForGodkjenning}
+                            senesteFrist={refusjon.senestMuligeGodkjenningsfrist}
+                        />
                         {brukerContext.innloggetBruker.harKorreksjonTilgang && (
                             <MerkForUnntakOmInntekterToMånederFrem refusjon={refusjon} />
                         )}

--- a/saksbehandler/vite.config.ts
+++ b/saksbehandler/vite.config.ts
@@ -7,7 +7,7 @@ const axios = require('axios');
 // https://vitejs.dev/config/
 export default defineConfig({
     preview: {
-        port: 3000,
+        port: 3002,
     },
     resolve: {
         alias: {
@@ -18,7 +18,7 @@ export default defineConfig({
     plugins: [react(), svgr()],
 
     server: {
-        port: 3000,
+        port: 3002,
         proxy: {
             '/api': { target: 'http://localhost:8081', changeOrigin: true },
             '/internarbeidsflatedecorator': {


### PR DESCRIPTION
# Forleng frist - manglende informasjon om maks forlengelse

Et nytt endepunkt i backend som leverer ut maks forlengelsesfrist gjør det mulig å
snevre inn hva som er valgbart i forlengelse-modalen.

I tillegg rydder vi litt i frontend-koden slik at datovelger og input-felt er i bedre synk,
og sørger for at når modalen lukkes så vil valgene i radioknappene for begrunnelse faktisk slettes.

## Før
https://github.com/user-attachments/assets/16a0c2d0-be13-403e-8340-82cba085ab7b

## Etter
https://github.com/user-attachments/assets/00b036c4-e077-4ec5-a901-0dbfb8b30d32

