### PR TITLE
Fornuftig feilmelding ved henting av inntekter frem i tid

### DIFF
--- a/saksbehandler/src/refusjon/MerkForUnntakOmInntekterFremITid/MerkForUnntakOmInntekterFremITid.tsx
+++ b/saksbehandler/src/refusjon/MerkForUnntakOmInntekterFremITid/MerkForUnntakOmInntekterFremITid.tsx
@@ -7,6 +7,8 @@ import { useForm, SubmitHandler } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Refusjon } from '~/types/refusjon';
+import { FeilkodeError } from '~/types';
+import { Feilkode, Feilmeldinger } from '~/feilkodemapping';
 
 const schema = z.object({
     merking: z.coerce
@@ -59,8 +61,13 @@ const ModalForm: FunctionComponent<{ refusjon: Refusjon; setOpen: (open: boolean
         try {
             await merkForUnntakOmInntekterFremITid(refusjon.id, data.merking);
             setOpen(false);
-        } catch {
-            setError('merking', { type: 'manual', message: 'Noe gikk galt' });
+        } catch (error) {
+            if (error instanceof FeilkodeError) {
+                const feilmeldingTekst = Feilmeldinger[error.message as Feilkode];
+                setError('merking', { type: 'manual', message: feilmeldingTekst });
+            } else {
+                setError('merking', { type: 'manual', message: 'Noe gikk galt' });
+            }
         }
     };
 


### PR DESCRIPTION
Når saksbehandler markerer en refusjon slik at det kan hentes inntekter frem i tid, men arbeidsgiver allerede har hentet inntekter en mnd frem, vil vi kaste en feilmelding. Men en opprydning i frontend har ført til at denne feilmeldingen blir en generisk "noe gikk galt", som skaper forvirring.


# Før:
![image](https://github.com/user-attachments/assets/3476b5f5-8b8f-4be2-8f14-6d760799878c)

# Etter:
![image](https://github.com/user-attachments/assets/d5572086-64d2-4782-ab6b-7d185501d40d)
