### PR TITLE
Legg til logg-destinasjoner

### DIFF
--- a/.nais/arbeidsgiver/nais.yml
+++ b/.nais/arbeidsgiver/nais.yml
@@ -37,6 +37,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: nodejs
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   {{#if labs}}
   replicas:
     min: 1

--- a/.nais/saksbehandler/nais-dev-gcp.yml
+++ b/.nais/saksbehandler/nais-dev-gcp.yml
@@ -44,6 +44,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: nodejs
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   accessPolicy:
     outbound:
       rules:

--- a/.nais/saksbehandler/nais-prod-gcp.yml
+++ b/.nais/saksbehandler/nais-prod-gcp.yml
@@ -44,6 +44,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: nodejs
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   accessPolicy:
     outbound:
       rules:


### PR DESCRIPTION
Vi ønsker å eksportere loggene våre til kibana
selv etter 1. juni!

Nais-plattformen har deprekert elasticsearch, og
derfor må vi eksplisitt legge til elastic til
listen over logg-destinasjoner i nais-yaml'en