### PR TITLE
fix. fikset en visningsfeil for kontonummer på vtao

### DIFF
--- a/komponenter/src/KvitteringSide/KvitteringSideVTAO/InformasjonFraAvtaleVTAO.tsx
+++ b/komponenter/src/KvitteringSide/KvitteringSideVTAO/InformasjonFraAvtaleVTAO.tsx
@@ -110,7 +110,7 @@ const InformasjonFraAvtalenVTAO = (props: Props) => {
                     oppdatere det hos Altinn.
                 </EksternLenke>
             </BodyShort>
-            {bedriftKontonummer === null && !åpnetFørsteGang && (
+            {bedriftKontonummer === null && åpnetFørsteGang && (
                 <>
                     <VerticalSpacer rem={1} />
                     <Alert variant="error" size="small">

--- a/komponenter/src/KvitteringSide/KvitteringSideVTAO/KvitteringSideVTAO.tsx
+++ b/komponenter/src/KvitteringSide/KvitteringSideVTAO/KvitteringSideVTAO.tsx
@@ -114,6 +114,7 @@ const KvitteringSideVTAO: FunctionComponent<Props> = (props: Props) => {
                 bedriftKontonummer={refusjon.refusjonsgrunnlag.bedriftKontonummer}
                 bedriftKontonummerInnhentetTidspunkt={refusjon.refusjonsgrunnlag.bedriftKontonummerInnhentetTidspunkt}
                 innloggetRolle={innloggetRolle}
+                åpnetFørsteGang={refusjon.åpnetFørsteGang}
             />
             <VerticalSpacer rem={2} />
             <TilskuddssatsVTAO tilskuddsgrunnlag={refusjon.refusjonsgrunnlag.tilskuddsgrunnlag} />


### PR DESCRIPTION
* Vi viser en melding om manglende kontonummer for vtao fordi de riktige props'ene ikke blir sendt inn.