### PR TITLE
fix. fikset filter-context

### DIFF
--- a/saksbehandler/src/refusjon/oversikt/FilterContext.tsx
+++ b/saksbehandler/src/refusjon/oversikt/FilterContext.tsx
@@ -7,11 +7,11 @@ import { Tiltak } from '~/types/tiltak';
 import { SortingOrder } from '~/types/filter';
 
 export interface Filter extends RefusjonsAktor {
-    status?: RefusjonStatus | undefined;
-    tiltakstype?: Tiltak | undefined;
-    sorting?: SortingOrder | undefined;
-    page?: number | undefined;
-    size?: number | undefined;
+    status?: RefusjonStatus;
+    tiltakstype?: Tiltak;
+    sorting?: SortingOrder;
+    page?: number;
+    size?: number;
 }
 
 export interface RefusjonsAktor {
@@ -83,10 +83,7 @@ export const FilterProvider: FunctionComponent<PropsWithChildren> = (props) => {
     };
 
     const oppdaterFilter = (nyttFilter: Partial<Filter>) => {
-        // Ved å sette inn "page: 0" i midten av objektet oppnår vi at alle andre endringer
-        // i filter fører til at paginering nullstilles, med mindre endringen ER paginering
-        // (da overstyres "page: 0" av den valgte siden i stedet)
-        const nyttMergedFilter = { ...filter, page: 0, ...nyttFilter };
+        const nyttMergedFilter = { ...filter, page: undefined, ...nyttFilter };
         setFilter(nyttMergedFilter);
         filterCookie.oppdatereSokeVerdiCookie({ ...nyttMergedFilter });
     };


### PR DESCRIPTION
* Fikse problem med filter hvor vi får evig loop og 'Warning: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render.'
* Fiksen innebærer å sette filter-state til samme objekt istedenfor å lage en shallow copy. Da vil det ikke trigges en re-render siden objektet i minnet er likt.