### PR TITLE
Endre dato i tekst til å spesifisere dagen etter refusjonsperioden er ferdig

### DIFF
--- a/arbeidsgiver/src/komponenter/UtregningsradHvaInngårIDette.tsx
+++ b/arbeidsgiver/src/komponenter/UtregningsradHvaInngårIDette.tsx
@@ -4,7 +4,7 @@ import { inntektBeskrivelse } from '../refusjon/RefusjonSide/inntektsmelding/Inn
 
 import { formatterPenger } from '~/utils/PengeUtils';
 import { Inntektslinje, Tilskuddsgrunnlag } from '~/types/refusjon';
-import { formatterDato, getMåned, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
+import { formaterDato, getMåned, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
 
 type Props = {
     inntekter: Inntektslinje[];
@@ -37,9 +37,7 @@ const UtregningsradHvaInngårIDette: FunctionComponent<Props> = (props) => {
                                     <Table.DataCell style={{ maxWidth: '10rem' }}>
                                         {inntektBeskrivelse(inntekt.beskrivelse)}
                                     </Table.DataCell>
-                                    <Table.DataCell>
-                                        {formatterDato(inntekt.måned, NORSK_MÅNEDÅR_FORMAT)}
-                                    </Table.DataCell>
+                                    <Table.DataCell>{formaterDato(inntekt.måned, NORSK_MÅNEDÅR_FORMAT)}</Table.DataCell>
                                     <Table.DataCell>{formatterPenger(inntekt.beløp)}</Table.DataCell>
                                     <Table.DataCell>
                                         {erFerietrekkForAnnenMåned && (

--- a/arbeidsgiver/src/refusjon/KvitteringKorreksjon/InntekterFraAMeldingenKorreksjon.tsx
+++ b/arbeidsgiver/src/refusjon/KvitteringKorreksjon/InntekterFraAMeldingenKorreksjon.tsx
@@ -13,7 +13,7 @@ import sortBy from 'lodash.sortby';
 import { lønnsbeskrivelseTekst } from '~/types/messages';
 import { Korreksjon } from '~/types/refusjon';
 import BEMHelper from '~/utils/bem';
-import { formatterDato, formatterPeriode, månedsNavn, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
+import { formaterDato, formaterPeriode, månedsNavn, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
 
 const inntektBeskrivelse = (beskrivelse: string | undefined) => {
     if (beskrivelse === undefined) {
@@ -118,11 +118,11 @@ const InntekterFraAMeldingenKorreksjon: FunctionComponent<Props> = ({ korreksjon
                                     return (
                                         <tr key={inntekt.id}>
                                             <td>{inntektBeskrivelse(inntekt.beskrivelse)}</td>
-                                            <td>{formatterDato(inntekt.måned, NORSK_MÅNEDÅR_FORMAT)}</td>
+                                            <td>{formaterDato(inntekt.måned, NORSK_MÅNEDÅR_FORMAT)}</td>
 
                                             <td>
                                                 {inntekt.opptjeningsperiodeFom && inntekt.opptjeningsperiodeTom ? (
-                                                    formatterPeriode(
+                                                    formaterPeriode(
                                                         inntekt.opptjeningsperiodeFom,
                                                         inntekt.opptjeningsperiodeTom,
                                                         'DD.MM'

--- a/arbeidsgiver/src/refusjon/KvitteringKorreksjon/InntekterFraAMeldingenKorreksjon.tsx
+++ b/arbeidsgiver/src/refusjon/KvitteringKorreksjon/InntekterFraAMeldingenKorreksjon.tsx
@@ -13,7 +13,7 @@ import sortBy from 'lodash.sortby';
 import { lønnsbeskrivelseTekst } from '~/types/messages';
 import { Korreksjon } from '~/types/refusjon';
 import BEMHelper from '~/utils/bem';
-import { formaterDato, formaterPeriode, månedsNavn, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
+import { formaterDato, formaterPeriode, månedsNavn, NORSK_DATO_MÅNED_FORMAT, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
 
 const inntektBeskrivelse = (beskrivelse: string | undefined) => {
     if (beskrivelse === undefined) {
@@ -125,7 +125,7 @@ const InntekterFraAMeldingenKorreksjon: FunctionComponent<Props> = ({ korreksjon
                                                     formaterPeriode(
                                                         inntekt.opptjeningsperiodeFom,
                                                         inntekt.opptjeningsperiodeTom,
-                                                        'DD.MM'
+                                                        NORSK_DATO_MÅNED_FORMAT
                                                     )
                                                 ) : (
                                                     <em>Ikke rapportert opptjenings&shy;periode</em>

--- a/arbeidsgiver/src/refusjon/KvitteringKorreksjon/KorreksjonInfo.tsx
+++ b/arbeidsgiver/src/refusjon/KvitteringKorreksjon/KorreksjonInfo.tsx
@@ -4,7 +4,7 @@ import VerticalSpacer from '~/VerticalSpacer';
 
 import { formatterPenger } from '~/utils/PengeUtils';
 import { korreksjonsgrunnTekst, tiltakstypeTekst } from '~/types/messages';
-import { formatterDato } from '~/utils';
+import { formaterDato } from '~/utils';
 import { Korreksjon, Korreksjonsgrunn } from '~/types/refusjon';
 import { KorreksjonStatus } from '~/types/status';
 
@@ -39,7 +39,7 @@ const KorreksjonInfo: FunctionComponent<Props> = (props) => {
                         Det er blitt foretatt en ny beregning av refusjonen for sommerjobb. Det tidligere utbetalte
                         beløpet er fratrukket i denne korrigerte beregningen. Det vil bli etterbetalt{' '}
                         <b>{formatterPenger(refusjonsbelop)}</b>. Denne korreksjonen ble registrert{' '}
-                        {formatterDato(props.korreksjon.godkjentTidspunkt!)}. Pengene vil være på konto i løpet av 3-4
+                        {formaterDato(props.korreksjon.godkjentTidspunkt!)}. Pengene vil være på konto i løpet av 3-4
                         dager etter dette.
                     </BodyShort>
                     <VerticalSpacer rem={1} />
@@ -54,7 +54,7 @@ const KorreksjonInfo: FunctionComponent<Props> = (props) => {
                         {tiltakstypeTekst[props.korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype]}. Denne
                         korreksjonen er nå utbetalt. Det tidligere utbetalte beløpet er fratrukket i denne korrigerte
                         beregningen. Det er nå etterbetalt <b>{formatterPenger(refusjonsbelop)}</b>. Denne korreksjonen
-                        ble registrert {formatterDato(props.korreksjon.godkjentTidspunkt!)}.
+                        ble registrert {formaterDato(props.korreksjon.godkjentTidspunkt!)}.
                     </BodyShort>
                     <VerticalSpacer rem={1} />
                     <Korreksjonsgrunner />

--- a/arbeidsgiver/src/refusjon/KvitteringKorreksjon/KvitteringKorreksjon.tsx
+++ b/arbeidsgiver/src/refusjon/KvitteringKorreksjon/KvitteringKorreksjon.tsx
@@ -10,7 +10,7 @@ import Utregning from '@/komponenter/Utregning';
 import VerticalSpacer from '~/VerticalSpacer';
 import { Aktsomhet, KorreksjonStatus, korreksjonStatusTekst } from '~/types';
 import { Korreksjon, Refusjon } from '~/types/refusjon';
-import { formatterDato, NORSK_DATO_OG_TID_FORMAT } from '~/utils';
+import { formaterDato, NORSK_DATO_OG_TID_FORMAT } from '~/utils';
 import { storForbokstav } from '~/utils/stringUtils';
 
 import InntekterFraAMeldingenKorreksjon from './InntekterFraAMeldingenKorreksjon';
@@ -34,7 +34,7 @@ const KvitteringKorreksjon = (props: Props) => {
                     <Tag variant="info">
                         {storForbokstav(korreksjonStatusTekst[korreksjon.status])}{' '}
                         {korreksjon.status === KorreksjonStatus.TILLEGSUTBETALING &&
-                            formatterDato(korreksjon.godkjentTidspunkt!, NORSK_DATO_OG_TID_FORMAT)}
+                            formaterDato(korreksjon.godkjentTidspunkt!, NORSK_DATO_OG_TID_FORMAT)}
                     </Tag>
                 </div>
                 <VerticalSpacer rem={1} />
@@ -77,7 +77,7 @@ const KvitteringKorreksjon = (props: Props) => {
                                 Kvittering for refusjon
                             </Heading>
                             <Tag variant="info">
-                                Sendt krav {formatterDato(refusjon.godkjentAvArbeidsgiver!, NORSK_DATO_OG_TID_FORMAT)}
+                                Sendt krav {formaterDato(refusjon.godkjentAvArbeidsgiver!, NORSK_DATO_OG_TID_FORMAT)}
                             </Tag>
                         </div>
                         <VerticalSpacer rem={1} />

--- a/arbeidsgiver/src/refusjon/KvitteringSide/KvitteringSide.tsx
+++ b/arbeidsgiver/src/refusjon/KvitteringSide/KvitteringSide.tsx
@@ -15,7 +15,7 @@ import TidligereRefunderbarBeløpKvittering from '@/refusjon/RefusjonSide/Tidlig
 import Utregning from '@/komponenter/Utregning';
 import VerticalSpacer from '~/VerticalSpacer';
 import { Aktsomhet, statusTekst, tiltakstypeTekst, RefusjonStatus, Refusjon } from '~/types';
-import { formatterDato, NORSK_DATO_FORMAT, NORSK_DATO_OG_TID_FORMAT } from '~/utils';
+import { formaterDato, NORSK_DATO_FORMAT, NORSK_DATO_OG_TID_FORMAT } from '~/utils';
 import { storForbokstav } from '~/utils/stringUtils';
 
 export const etikettForRefusjonStatus = (refusjon: Refusjon): ReactElement => {
@@ -25,7 +25,7 @@ export const etikettForRefusjonStatus = (refusjon: Refusjon): ReactElement => {
         return (
             <Tag variant="info">
                 {storForbokstav(statusTekst[refusjon.status])}{' '}
-                {refusjon.utbetaltTidspunkt && formatterDato(refusjon.utbetaltTidspunkt, NORSK_DATO_FORMAT)}
+                {refusjon.utbetaltTidspunkt && formaterDato(refusjon.utbetaltTidspunkt, NORSK_DATO_FORMAT)}
             </Tag>
         );
     } else {
@@ -33,7 +33,7 @@ export const etikettForRefusjonStatus = (refusjon: Refusjon): ReactElement => {
             <Tag variant="info">
                 {storForbokstav(statusTekst[refusjon.status])}{' '}
                 {refusjon.godkjentAvArbeidsgiver &&
-                    formatterDato(refusjon.godkjentAvArbeidsgiver, NORSK_DATO_OG_TID_FORMAT)}
+                    formaterDato(refusjon.godkjentAvArbeidsgiver, NORSK_DATO_OG_TID_FORMAT)}
             </Tag>
         );
     }

--- a/arbeidsgiver/src/refusjon/RefusjonSide/FeilSide.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/FeilSide.tsx
@@ -6,7 +6,7 @@ import { formatterPenger } from '~/utils/PengeUtils';
 import { Alert, Label, BodyShort, Heading } from '@navikt/ds-react';
 import Boks from '~/Boks';
 import { tiltakstypeTekst } from '~/types/messages';
-import { formatterPeriode } from '~/utils';
+import { formaterPeriode } from '~/utils';
 
 type AlertStripeType = 'info' | 'success' | 'warning' | 'error';
 
@@ -29,7 +29,7 @@ const FeilSide: FunctionComponent<Props> = (props) => {
             <VerticalSpacer rem={1} />
             <Label>Periode:</Label>
             <BodyShort size="small">
-                {formatterPeriode(
+                {formaterPeriode(
                     refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
                     refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom
                 )}

--- a/arbeidsgiver/src/refusjon/RefusjonSide/InntekterFraAMeldingenGammel.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/InntekterFraAMeldingenGammel.tsx
@@ -11,7 +11,13 @@ import Boks from '~/Boks';
 import { lønnsbeskrivelseTekst } from '~/types/messages';
 import { Refusjon } from '~/types/refusjon';
 import BEMHelper from '~/utils/bem';
-import { formaterDato, formaterPeriode, NORSK_DATO_OG_TID_FORMAT, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
+import {
+    formaterDato,
+    formaterPeriode,
+    NORSK_DATO_MÅNED_FORMAT,
+    NORSK_DATO_OG_TID_FORMAT,
+    NORSK_MÅNEDÅR_FORMAT,
+} from '~/utils';
 
 const inntektBeskrivelse = (beskrivelse: string | undefined) => {
     if (beskrivelse === undefined) {
@@ -96,7 +102,7 @@ const InntekterFraAMeldingen: FunctionComponent<Props> = ({ refusjon }) => {
                                                 formaterPeriode(
                                                     inntekt.opptjeningsperiodeFom,
                                                     inntekt.opptjeningsperiodeTom,
-                                                    'DD.MM'
+                                                    NORSK_DATO_MÅNED_FORMAT
                                                 )
                                             ) : (
                                                 <em>Ikke rapportert opptjenings&shy;periode</em>

--- a/arbeidsgiver/src/refusjon/RefusjonSide/InntekterFraAMeldingenGammel.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/InntekterFraAMeldingenGammel.tsx
@@ -11,7 +11,7 @@ import Boks from '~/Boks';
 import { lønnsbeskrivelseTekst } from '~/types/messages';
 import { Refusjon } from '~/types/refusjon';
 import BEMHelper from '~/utils/bem';
-import { formatterDato, formatterPeriode, NORSK_DATO_OG_TID_FORMAT, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
+import { formaterDato, formaterPeriode, NORSK_DATO_OG_TID_FORMAT, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
 
 const inntektBeskrivelse = (beskrivelse: string | undefined) => {
     if (beskrivelse === undefined) {
@@ -51,7 +51,7 @@ const InntekterFraAMeldingen: FunctionComponent<Props> = ({ refusjon }) => {
             {refusjon.refusjonsgrunnlag.inntektsgrunnlag && (
                 <BodyShort size="small">
                     Sist hentet:{' '}
-                    {formatterDato(
+                    {formaterDato(
                         refusjon.refusjonsgrunnlag.inntektsgrunnlag.innhentetTidspunkt,
                         NORSK_DATO_OG_TID_FORMAT
                     )}
@@ -89,11 +89,11 @@ const InntekterFraAMeldingen: FunctionComponent<Props> = ({ refusjon }) => {
                                 ).map((inntekt) => (
                                     <tr key={inntekt.id}>
                                         <td>{inntektBeskrivelse(inntekt.beskrivelse)}</td>
-                                        <td>{formatterDato(inntekt.måned, NORSK_MÅNEDÅR_FORMAT)}</td>
+                                        <td>{formaterDato(inntekt.måned, NORSK_MÅNEDÅR_FORMAT)}</td>
 
                                         <td>
                                             {inntekt.opptjeningsperiodeFom && inntekt.opptjeningsperiodeTom ? (
-                                                formatterPeriode(
+                                                formaterPeriode(
                                                     inntekt.opptjeningsperiodeFom,
                                                     inntekt.opptjeningsperiodeTom,
                                                     'DD.MM'

--- a/arbeidsgiver/src/refusjon/RefusjonSide/InntekterFraTiltaketSpørsmål.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/InntekterFraTiltaketSpørsmål.tsx
@@ -9,7 +9,7 @@ import { BodyShort, Heading, Label, Radio, RadioGroup, debounce } from '@navikt/
 import BruttolønnUtbetaltInput from '@/refusjon/RefusjonSide/BruttolønnUtbetaltInput';
 import BEMHelper from '~/utils/bem';
 import { Refusjon } from '~/types/refusjon';
-import { formatterPeriode, månedsNavn } from '~/utils';
+import { formaterPeriode, månedsNavn } from '~/utils';
 import { tiltakstypeTekst } from '~/types/messages';
 interface Properties {
     setVisRefusjonInnsending: Dispatch<SetStateAction<boolean>>;
@@ -24,7 +24,7 @@ const InntekterFraTiltaketSpørsmål: FunctionComponent<Properties> = ({ setVisR
     const [endringBruttoLønn, setEndringBruttoLønn] = useState<string>(endretBruttoLønn?.toString() ?? '');
 
     const refusjonNummer = `${tilskuddsgrunnlag.avtaleNr}-${tilskuddsgrunnlag.løpenummer}`;
-    const periode = formatterPeriode(
+    const periode = formaterPeriode(
         refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
         refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom,
         'DD.MM'
@@ -54,7 +54,7 @@ const InntekterFraTiltaketSpørsmål: FunctionComponent<Properties> = ({ setVisR
         <div className={cls.element('inntekter-fra-tiltaket-boks')}>
             <Heading level="3" size="small">
                 Inntekter som skal refunderes for{' '}
-                {formatterPeriode(tilskuddsgrunnlag.tilskuddFom, tilskuddsgrunnlag.tilskuddTom)}
+                {formaterPeriode(tilskuddsgrunnlag.tilskuddFom, tilskuddsgrunnlag.tilskuddTom)}
             </Heading>
             <VerticalSpacer rem={1} />
             <BodyShort size="small">

--- a/arbeidsgiver/src/refusjon/RefusjonSide/InntekterFraTiltaketSpørsmål.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/InntekterFraTiltaketSpørsmål.tsx
@@ -9,7 +9,7 @@ import { BodyShort, Heading, Label, Radio, RadioGroup, debounce } from '@navikt/
 import BruttolønnUtbetaltInput from '@/refusjon/RefusjonSide/BruttolønnUtbetaltInput';
 import BEMHelper from '~/utils/bem';
 import { Refusjon } from '~/types/refusjon';
-import { formaterPeriode, månedsNavn } from '~/utils';
+import { formaterPeriode, månedsNavn, NORSK_DATO_MÅNED_FORMAT } from '~/utils';
 import { tiltakstypeTekst } from '~/types/messages';
 interface Properties {
     setVisRefusjonInnsending: Dispatch<SetStateAction<boolean>>;
@@ -27,7 +27,7 @@ const InntekterFraTiltaketSpørsmål: FunctionComponent<Properties> = ({ setVisR
     const periode = formaterPeriode(
         refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
         refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom,
-        'DD.MM'
+        NORSK_DATO_MÅNED_FORMAT
     );
 
     useEffect(() => {

--- a/arbeidsgiver/src/refusjon/RefusjonSide/InntekterFraTiltaketSvar.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/InntekterFraTiltaketSvar.tsx
@@ -6,7 +6,7 @@ import InntekterOpptjentIPeriodeTabell from './InntekterOpptjentIPeriodeTabell';
 import Boks from '~/Boks';
 import { valgtBruttoLønn } from '@/utils/inntekterUtiles';
 import { Refusjonsgrunnlag } from '~/types/refusjon';
-import { formatterPeriode, månedsNavn } from '~/utils';
+import { formaterPeriode, månedsNavn } from '~/utils';
 import { tiltakstypeTekst } from '~/types/messages';
 
 type Props = {
@@ -15,7 +15,7 @@ type Props = {
 
 const InntekterFraTiltaketSvar: FunctionComponent<Props> = (props) => {
     const refusjonNummer = `${props.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr}-${props.refusjonsgrunnlag.tilskuddsgrunnlag.løpenummer}`;
-    const periode = formatterPeriode(
+    const periode = formaterPeriode(
         props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
         props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom,
         'DD.MM'
@@ -38,7 +38,7 @@ const InntekterFraTiltaketSvar: FunctionComponent<Props> = (props) => {
             <Boks variant="grønn">
                 <Heading size="small">
                     Inntekter som refunderes for{' '}
-                    {formatterPeriode(
+                    {formaterPeriode(
                         props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
                         props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom
                     )}

--- a/arbeidsgiver/src/refusjon/RefusjonSide/InntekterFraTiltaketSvar.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/InntekterFraTiltaketSvar.tsx
@@ -6,7 +6,7 @@ import InntekterOpptjentIPeriodeTabell from './InntekterOpptjentIPeriodeTabell';
 import Boks from '~/Boks';
 import { valgtBruttoLønn } from '@/utils/inntekterUtiles';
 import { Refusjonsgrunnlag } from '~/types/refusjon';
-import { formaterPeriode, månedsNavn } from '~/utils';
+import { formaterPeriode, månedsNavn, NORSK_DATO_MÅNED_FORMAT } from '~/utils';
 import { tiltakstypeTekst } from '~/types/messages';
 
 type Props = {
@@ -18,7 +18,7 @@ const InntekterFraTiltaketSvar: FunctionComponent<Props> = (props) => {
     const periode = formaterPeriode(
         props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
         props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom,
-        'DD.MM'
+        NORSK_DATO_MÅNED_FORMAT
     );
 
     if (

--- a/arbeidsgiver/src/refusjon/RefusjonSide/InntekterOpptjentIPeriodeTabell.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/InntekterOpptjentIPeriodeTabell.tsx
@@ -8,7 +8,7 @@ import { inntektBeskrivelse } from './inntektsmelding/InntekterFraAMeldingen';
 import '../RefusjonSide/InntekterFraAMeldingen.less';
 import { Inntektslinje } from '~/types/refusjon';
 import BEMHelper from '~/utils/bem';
-import { formatterDato, formatterPeriode, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
+import { formaterDato, formaterPeriode, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
 
 type Props = {
     inntekter: Inntektslinje[];
@@ -46,10 +46,10 @@ const InntekterOpptjentIPeriodeTabell: FunctionComponent<Props> = (props) => {
                     {sorterInntektslinjer(inntekterHuketAvForOpptjentIPeriode).map((inntekt) => (
                         <tr key={inntekt.id}>
                             <td>{inntektBeskrivelse(inntekt.beskrivelse)}</td>
-                            <td>{formatterDato(inntekt.måned, NORSK_MÅNEDÅR_FORMAT)}</td>
+                            <td>{formaterDato(inntekt.måned, NORSK_MÅNEDÅR_FORMAT)}</td>
                             <td>
                                 {inntekt.opptjeningsperiodeFom && inntekt.opptjeningsperiodeTom ? (
-                                    formatterPeriode(
+                                    formaterPeriode(
                                         inntekt.opptjeningsperiodeFom,
                                         inntekt.opptjeningsperiodeTom,
                                         'DD.MM'

--- a/arbeidsgiver/src/refusjon/RefusjonSide/InntekterOpptjentIPeriodeTabell.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/InntekterOpptjentIPeriodeTabell.tsx
@@ -8,7 +8,7 @@ import { inntektBeskrivelse } from './inntektsmelding/InntekterFraAMeldingen';
 import '../RefusjonSide/InntekterFraAMeldingen.less';
 import { Inntektslinje } from '~/types/refusjon';
 import BEMHelper from '~/utils/bem';
-import { formaterDato, formaterPeriode, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
+import { formaterDato, formaterPeriode, NORSK_DATO_MÅNED_FORMAT, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
 
 type Props = {
     inntekter: Inntektslinje[];
@@ -52,7 +52,7 @@ const InntekterOpptjentIPeriodeTabell: FunctionComponent<Props> = (props) => {
                                     formaterPeriode(
                                         inntekt.opptjeningsperiodeFom,
                                         inntekt.opptjeningsperiodeTom,
-                                        'DD.MM'
+                                        NORSK_DATO_MÅNED_FORMAT
                                     )
                                 ) : (
                                     <em>Ikke rapportert opptjenings&shy;periode</em>

--- a/arbeidsgiver/src/refusjon/RefusjonSide/Refusjon.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/Refusjon.tsx
@@ -15,7 +15,7 @@ import {
 import useSWRMutation from 'swr/mutation';
 import { mutate } from 'swr';
 import { RefusjonStatus } from '~/types/status';
-import { formatterDato } from '~/utils';
+import { beregnDagenEtterOgFormater, formaterDato } from '~/utils';
 import { Refusjon as RefusjonType } from '~/types/refusjon';
 import { BrukerContextType } from '~/types/brukerContextType';
 import { useInnloggetBruker } from '@/bruker/BrukerContext';
@@ -85,8 +85,8 @@ const Komponent: FunctionComponent = () => {
                         <>
                             <BodyShort style={{ marginBottom: '1rem' }}>
                                 Du kan søke om refusjon fra{' '}
-                                {formatterDato(refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom)} når perioden
-                                er over.
+                                {beregnDagenEtterOgFormater(refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom)}{' '}
+                                når perioden er over.
                             </BodyShort>
                             <BodyShort>
                                 Siste frist for å sende inn kravet er senest to måneder etter at perioden er over. Hvis
@@ -103,7 +103,7 @@ const Komponent: FunctionComponent = () => {
             return (
                 <FeilSide
                     advarselType="warning"
-                    feiltekst={`Fristen for å søke om refusjon for denne perioden gikk ut ${formatterDato(
+                    feiltekst={`Fristen for å søke om refusjon for denne perioden gikk ut ${formaterDato(
                         refusjon.fristForGodkjenning
                     )}. Innvilget tilskudd er derfor trukket tilbake.`}
                 />

--- a/arbeidsgiver/src/refusjon/RefusjonSide/RefusjonGodkjennModal.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/RefusjonGodkjennModal.tsx
@@ -5,7 +5,7 @@ import { BodyShort } from '@navikt/ds-react';
 import VerticalSpacer from '~/VerticalSpacer';
 import { formatterPenger } from '~/utils/PengeUtils';
 import { Refusjon } from '~/types/refusjon';
-import { formatterPeriode } from '~/utils';
+import { formaterPeriode } from '~/utils';
 
 interface Properties {
     refusjon: Refusjon;
@@ -32,7 +32,7 @@ const RefusjonGodkjennModal: FunctionComponent<Properties> = ({
                 <BodyShort size="small">
                     Du søker nå om refusjon for hele den avtalte perioden{' '}
                     <b>
-                        {formatterPeriode(tilskuddsgrunnlag.tilskuddFom, tilskuddsgrunnlag.tilskuddTom)}. Dette kan du
+                        {formaterPeriode(tilskuddsgrunnlag.tilskuddFom, tilskuddsgrunnlag.tilskuddTom)}. Dette kan du
                         kun gjøre en gang.
                     </b>{' '}
                     Sikre deg derfor at alle inntekter innenfor perioden er rapportert inn og at refusjonsbeløpet
@@ -56,7 +56,7 @@ const RefusjonGodkjennModal: FunctionComponent<Properties> = ({
                 <BodyShort size="small">
                     Du godtar nå beløpet for den avtalte perioden{' '}
                     <b>
-                        {formatterPeriode(tilskuddsgrunnlag.tilskuddFom, tilskuddsgrunnlag.tilskuddTom)}. Dette kan du
+                        {formaterPeriode(tilskuddsgrunnlag.tilskuddFom, tilskuddsgrunnlag.tilskuddTom)}. Dette kan du
                         kun gjøre en gang.
                     </b>{' '}
                     Sikre deg derfor at alle inntekter innenfor perioden er rapportert inn og at beløpet stemmer.

--- a/arbeidsgiver/src/refusjon/RefusjonSide/RefusjonIngress.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/RefusjonIngress.tsx
@@ -4,7 +4,7 @@ import { Tag, BodyShort, Heading } from '@navikt/ds-react';
 import { Refusjon } from '~/types/refusjon';
 import BEMHelper from '~/utils/bem';
 import { storForbokstav } from '~/utils/stringUtils';
-import { formatterDato, NORSK_DATO_OG_TID_FORMAT } from '~/utils';
+import { formaterDato, NORSK_DATO_OG_TID_FORMAT } from '~/utils';
 import { statusTekst, tiltakstypeTekst } from '~/types/messages';
 import EksternLenke from '~/EksternLenke/EksternLenke';
 
@@ -24,7 +24,7 @@ const RefusjonIngress: FunctionComponent<Properties> = ({ refusjon }: PropsWithC
                 <Tag variant="info" size="small">
                     {storForbokstav(statusTekst[refusjon.status])}{' '}
                     {refusjon.godkjentAvArbeidsgiver &&
-                        formatterDato(refusjon.godkjentAvArbeidsgiver, NORSK_DATO_OG_TID_FORMAT)}
+                        formaterDato(refusjon.godkjentAvArbeidsgiver, NORSK_DATO_OG_TID_FORMAT)}
                 </Tag>
             </div>
             <BodyShort size="small" className={cls.element('ingress-text')}>

--- a/arbeidsgiver/src/refusjon/RefusjonSide/SummeringBoks.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/SummeringBoks.tsx
@@ -8,7 +8,7 @@ import { formatterPenger } from '~/utils/PengeUtils';
 import Boks from '~/Boks';
 import { Refusjonsgrunnlag, Tilskuddsgrunnlag } from '~/types/refusjon';
 import { RefusjonStatus } from '~/types/status';
-import { formatterPeriode } from '~/utils';
+import { formaterPeriode } from '~/utils';
 
 type Props = {
     refusjonsgrunnlag: Refusjonsgrunnlag;
@@ -37,7 +37,7 @@ const SummeringBoks: FunctionComponent<Props> = (props) => {
                     <VerticalSpacer rem={0.5} />
                     <BodyShort size="small">
                         <b>{formatterPenger(props.refusjonsgrunnlag.beregning?.refusjonsbeløp || 0)}</b> for perioden{' '}
-                        {formatterPeriode(
+                        {formaterPeriode(
                             props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
                             props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom
                         )}{' '}
@@ -71,7 +71,7 @@ const SummeringBoks: FunctionComponent<Props> = (props) => {
                                         Godta{' '}
                                         <b>{formatterPenger(props.refusjonsgrunnlag.beregning?.refusjonsbeløp || 0)}</b>{' '}
                                         for perioden{' '}
-                                        {formatterPeriode(
+                                        {formaterPeriode(
                                             props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
                                             props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom
                                         )}{' '}
@@ -83,7 +83,7 @@ const SummeringBoks: FunctionComponent<Props> = (props) => {
                             <>
                                 <Label>
                                     Refusjonen er godtatt med {formatterPenger(0)} for perioden{' '}
-                                    {formatterPeriode(
+                                    {formaterPeriode(
                                         props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
                                         props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom
                                     )}
@@ -138,7 +138,7 @@ const SummeringBoks: FunctionComponent<Props> = (props) => {
                                 {formatterPenger(Math.abs(props.refusjonsgrunnlag.beregning?.refusjonsbeløp || 0))}
                             </b>{' '}
                             <b>{formatterPenger(0)}</b> for perioden{' '}
-                            {formatterPeriode(
+                            {formaterPeriode(
                                 props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
                                 props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom
                             )}
@@ -149,7 +149,7 @@ const SummeringBoks: FunctionComponent<Props> = (props) => {
                             Dere skylder{' '}
                             <b>{formatterPenger(Math.abs(props.refusjonsgrunnlag.beregning?.refusjonsbeløp || 0))}</b>{' '}
                             for perioden{' '}
-                            {formatterPeriode(
+                            {formaterPeriode(
                                 props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
                                 props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom
                             )}

--- a/arbeidsgiver/src/refusjon/RefusjonSide/SummeringsBoksNullbeløp.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/SummeringsBoksNullbeløp.tsx
@@ -7,7 +7,7 @@ import { formatterPenger } from '~/utils/PengeUtils';
 import Boks from '~/Boks';
 import VerticalSpacer from '~/VerticalSpacer';
 import { Refusjonsgrunnlag } from '~/types/refusjon';
-import { formatterPeriode } from '~/utils';
+import { formaterPeriode } from '~/utils';
 
 type Props = {
     refusjonsgrunnlag: Refusjonsgrunnlag;
@@ -23,7 +23,7 @@ const SummeringBoksNullbeløp: FunctionComponent<Props> = (props) => {
                 <VerticalSpacer rem={0.5} />
                 <Label>
                     Refusjonen er godtatt med {formatterPenger(0)} for perioden{' '}
-                    {formatterPeriode(
+                    {formaterPeriode(
                         props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
                         props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom
                     )}

--- a/arbeidsgiver/src/refusjon/RefusjonSide/TidligereRefunderbarBeløp.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/TidligereRefunderbarBeløp.tsx
@@ -9,7 +9,7 @@ import VerticalSpacer from '~/VerticalSpacer';
 import { Alert, Radio, RadioGroup, TextField, Heading, Label, BodyShort, debounce } from '@navikt/ds-react';
 import BEMHelper from '~/utils/bem';
 import { tiltakstypeTekst } from '~/types/messages';
-import { formatterDato } from '~/utils';
+import { formaterDato } from '~/utils';
 import { Refusjon } from '~/types/refusjon';
 
 interface Properties {
@@ -93,7 +93,7 @@ const TidligereRefunderbarBeløp: FunctionComponent<Properties> = ({ refusjon }:
             </RadioGroup>
             {fratrekk === true && (
                 <BodyShort size="small" className={cls.element('ny-frist')}>
-                    Ny frist for å søke refusjon: <strong>{formatterDato(refusjon.fristForGodkjenning)}</strong>
+                    Ny frist for å søke refusjon: <strong>{formaterDato(refusjon.fristForGodkjenning)}</strong>
                 </BodyShort>
             )}
 

--- a/arbeidsgiver/src/refusjon/RefusjonSide/informasjonAvtalen/InformasjonFraAvtalen.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/informasjonAvtalen/InformasjonFraAvtalen.tsx
@@ -8,7 +8,7 @@ import KIDInputValidator from '~/KIDInputValidator';
 import VerticalSpacer from '~/VerticalSpacer';
 import { Aktsomhet, tiltakstypeTekst } from '~/types';
 import { Refusjon } from '~/types/refusjon';
-import { formatterDato, formatterPeriode } from '~/utils';
+import { formaterDato, formaterPeriode } from '~/utils';
 import { formatterPenger } from '~/utils/PengeUtils';
 import React, { useCallback } from 'react';
 import { lagreBedriftKID } from '@/services/rest-service';
@@ -81,7 +81,7 @@ const InformasjonFraAvtalen = (props: Props) => {
             <IkonRad>
                 <Label>Periode: </Label>
                 <BodyShort size="small">
-                    {formatterPeriode(
+                    {formaterPeriode(
                         refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
                         refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom
                     )}
@@ -90,7 +90,7 @@ const InformasjonFraAvtalen = (props: Props) => {
             <VerticalSpacer rem={1} />
             <IkonRad>
                 <Label>Frist: </Label>
-                <BodyShort size="small">{formatterDato(refusjon.fristForGodkjenning)}</BodyShort>
+                <BodyShort size="small">{formaterDato(refusjon.fristForGodkjenning)}</BodyShort>
             </IkonRad>
             <VerticalSpacer rem={1} />
             <IkonRad>

--- a/arbeidsgiver/src/refusjon/RefusjonSide/inntektsmelding/InntektsMeldingHeader.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/inntektsmelding/InntektsMeldingHeader.tsx
@@ -1,7 +1,7 @@
 import { BodyShort, Heading } from '@navikt/ds-react';
 import { FunctionComponent } from 'react';
 import { Refusjonsgrunnlag } from '~/types/refusjon';
-import { formatterDato, månedsNavn, NORSK_DATO_OG_TID_FORMAT } from '~/utils';
+import { formaterDato, månedsNavn, NORSK_DATO_OG_TID_FORMAT } from '~/utils';
 import BEMHelper from '~/utils/bem';
 
 interface Properties {
@@ -35,7 +35,7 @@ const InntektsMeldingHeader: FunctionComponent<Properties> = ({
             {refusjonsgrunnlag.inntektsgrunnlag && (
                 <BodyShort size="small">
                     Sist hentet:{' '}
-                    {formatterDato(refusjonsgrunnlag.inntektsgrunnlag.innhentetTidspunkt, NORSK_DATO_OG_TID_FORMAT)}
+                    {formaterDato(refusjonsgrunnlag.inntektsgrunnlag.innhentetTidspunkt, NORSK_DATO_OG_TID_FORMAT)}
                 </BodyShort>
             )}
         </div>

--- a/arbeidsgiver/src/refusjon/RefusjonSide/inntektsmelding/inntektsmeldingTabell/InntektsmeldingTabellBody.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/inntektsmelding/inntektsmeldingTabell/InntektsmeldingTabellBody.tsx
@@ -6,7 +6,7 @@ import { inntektBeskrivelse } from '../InntekterFraAMeldingen';
 import InntektValg from './InntektValg';
 import { valgtBruttoLønn } from '@/utils/inntekterUtiles';
 import { Inntektslinje } from '~/types/refusjon';
-import { formatterDato, formatterPeriode, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
+import { formaterDato, formaterPeriode, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
 
 type Props = {
     refusjonId: string;
@@ -24,11 +24,11 @@ const InntektsmeldingTabellBody: FunctionComponent<Props> = (props) => {
             ).map((inntekt) => (
                 <tr key={inntekt.id}>
                     <td>{inntektBeskrivelse(inntekt.beskrivelse)}</td>
-                    <td>{formatterDato(inntekt.måned, NORSK_MÅNEDÅR_FORMAT)}</td>
+                    <td>{formaterDato(inntekt.måned, NORSK_MÅNEDÅR_FORMAT)}</td>
 
                     <td>
                         {inntekt.opptjeningsperiodeFom && inntekt.opptjeningsperiodeTom ? (
-                            formatterPeriode(inntekt.opptjeningsperiodeFom, inntekt.opptjeningsperiodeTom, 'DD.MM')
+                            formaterPeriode(inntekt.opptjeningsperiodeFom, inntekt.opptjeningsperiodeTom, 'DD.MM')
                         ) : (
                             <em>Ikke rapportert opptjenings&shy;periode</em>
                         )}

--- a/arbeidsgiver/src/refusjon/RefusjonSide/inntektsmelding/inntektsmeldingTabell/InntektsmeldingTabellBody.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/inntektsmelding/inntektsmeldingTabell/InntektsmeldingTabellBody.tsx
@@ -6,7 +6,7 @@ import { inntektBeskrivelse } from '../InntekterFraAMeldingen';
 import InntektValg from './InntektValg';
 import { valgtBruttoLønn } from '@/utils/inntekterUtiles';
 import { Inntektslinje } from '~/types/refusjon';
-import { formaterDato, formaterPeriode, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
+import { formaterDato, formaterPeriode, NORSK_DATO_MÅNED_FORMAT, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
 
 type Props = {
     refusjonId: string;
@@ -28,7 +28,11 @@ const InntektsmeldingTabellBody: FunctionComponent<Props> = (props) => {
 
                     <td>
                         {inntekt.opptjeningsperiodeFom && inntekt.opptjeningsperiodeTom ? (
-                            formaterPeriode(inntekt.opptjeningsperiodeFom, inntekt.opptjeningsperiodeTom, 'DD.MM')
+                            formaterPeriode(
+                                inntekt.opptjeningsperiodeFom,
+                                inntekt.opptjeningsperiodeTom,
+                                NORSK_DATO_MÅNED_FORMAT
+                            )
                         ) : (
                             <em>Ikke rapportert opptjenings&shy;periode</em>
                         )}

--- a/arbeidsgiver/src/refusjon/RefusjonSide/refusjonFullførNullbeløp/RefusjonFullførNullbeløpModal.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/refusjonFullførNullbeløp/RefusjonFullførNullbeløpModal.tsx
@@ -4,7 +4,7 @@ import { Alert } from '@navikt/ds-react';
 
 import { formatterPenger } from '~/utils/PengeUtils';
 import { Refusjon } from '~/types/refusjon';
-import { formatterPeriode } from '~/utils';
+import { formaterPeriode } from '~/utils';
 
 interface Properties {
     refusjon: Refusjon;
@@ -30,8 +30,8 @@ const RefusjonFullførNullbeløpModal: FunctionComponent<Properties> = ({
         >
             <Alert variant="warning">
                 Ved å fullføre denne refusjonen for den avtalte perioden{' '}
-                <b>{formatterPeriode(tilskuddsgrunnlag.tilskuddFom, tilskuddsgrunnlag.tilskuddTom)}.</b> godkjenner du
-                at refusjonsbeløpet er {formatterPenger(0)}
+                <b>{formaterPeriode(tilskuddsgrunnlag.tilskuddFom, tilskuddsgrunnlag.tilskuddTom)}.</b> godkjenner du at
+                refusjonsbeløpet er {formatterPenger(0)}
             </Alert>
         </GodkjennModal>
     );

--- a/komponenter/src/Boks/Boks.tsx
+++ b/komponenter/src/Boks/Boks.tsx
@@ -1,12 +1,11 @@
 import './Boks.less';
-import { Farger } from '~/utils/boksUtils';
 import { CSSProperties, FunctionComponent, PropsWithChildren } from 'react';
 import BEMHelper from '~/utils/bem';
 
 type Props = {
     className?: string;
     style?: CSSProperties;
-    variant: Farger;
+    variant: 'blå' | 'grønn' | 'grå' | 'hvit';
 };
 const cls = BEMHelper('boks');
 

--- a/komponenter/src/KvitteringSide/KvitteringSideMentor/InformasjonFraAvtaleMentor.tsx
+++ b/komponenter/src/KvitteringSide/KvitteringSideMentor/InformasjonFraAvtaleMentor.tsx
@@ -8,7 +8,7 @@ import KIDInputValidator from '~/KIDInputValidator';
 import VerticalSpacer from '~/VerticalSpacer';
 import { Aktsomhet, Refusjonsgrunnlag, RefusjonStatus } from '~/types';
 import { InnloggetRolle } from '~/types/brukerContextType';
-import { formatterDato, formatterPeriode, NORSK_DATO_OG_TID_FORMAT } from '~/utils';
+import { formaterDato, formaterPeriode, NORSK_DATO_OG_TID_FORMAT } from '~/utils';
 import { formatterPenger, visTallMedNorskFormatering } from '~/utils/PengeUtils';
 import { lagId } from '~/utils/stringUtils';
 
@@ -86,7 +86,7 @@ const InformasjonFraAvtalenMentor = (props: Props) => {
             </IkonRad>
             <IkonRad>
                 <Label>Periode: </Label>
-                <BodyShort size="small">{formatterPeriode(tilskuddFom, tilskuddTom)}</BodyShort>
+                <BodyShort size="small">{formaterPeriode(tilskuddFom, tilskuddTom)}</BodyShort>
             </IkonRad>
             <VerticalSpacer rem={1} />
             <IkonRad>
@@ -105,7 +105,7 @@ const InformasjonFraAvtalenMentor = (props: Props) => {
                         {bedriftKontonummerInnhentetTidspunkt ? (
                             <>
                                 {bedriftKontonummer ?? 'Ikke funnet'} (hentet{' '}
-                                {formatterDato(bedriftKontonummerInnhentetTidspunkt, NORSK_DATO_OG_TID_FORMAT)})
+                                {formaterDato(bedriftKontonummerInnhentetTidspunkt, NORSK_DATO_OG_TID_FORMAT)})
                             </>
                         ) : (
                             'Ikke oppgitt'

--- a/komponenter/src/KvitteringSide/KvitteringSideMentor/StatusEtikettMentor.tsx
+++ b/komponenter/src/KvitteringSide/KvitteringSideMentor/StatusEtikettMentor.tsx
@@ -17,7 +17,7 @@ const refusjonSendesDato = (refusjon: Refusjon): string => {
     const tidligsteDato = isBefore(enDagEtterTilskuddsperioden, morgendagensDato)
         ? morgendagensDato
         : enDagEtterTilskuddsperioden;
-    return formaterDato(tidligsteDato.toString());
+    return formaterDato(tidligsteDato);
 };
 
 export type StatusEtikettProps = { refusjon: Refusjon };

--- a/komponenter/src/KvitteringSide/KvitteringSideMentor/StatusEtikettMentor.tsx
+++ b/komponenter/src/KvitteringSide/KvitteringSideMentor/StatusEtikettMentor.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 import { Refusjon, RefusjonStatus, statusTekst } from '~/types';
-import { formatterDato } from '~/utils';
+import { formaterDato } from '~/utils';
 import { Tag } from '@navikt/ds-react';
 import { addDays, isBefore } from 'date-fns';
 import { NORSK_DATO_FORMAT } from '~/utils/datoUtils';
@@ -17,7 +17,7 @@ const refusjonSendesDato = (refusjon: Refusjon): string => {
     const tidligsteDato = isBefore(enDagEtterTilskuddsperioden, morgendagensDato)
         ? morgendagensDato
         : enDagEtterTilskuddsperioden;
-    return formatterDato(tidligsteDato.toString());
+    return formaterDato(tidligsteDato.toString());
 };
 
 export type StatusEtikettProps = { refusjon: Refusjon };
@@ -33,14 +33,14 @@ const StatusEtikettMentor = ({ refusjon }: StatusEtikettProps): ReactElement => 
         return (
             <Tag variant="info">
                 {storForbokstav(statusetikettTekst)}{' '}
-                {refusjon.utbetaltTidspunkt && formatterDato(refusjon.utbetaltTidspunkt, NORSK_DATO_FORMAT)}
+                {refusjon.utbetaltTidspunkt && formaterDato(refusjon.utbetaltTidspunkt, NORSK_DATO_FORMAT)}
             </Tag>
         );
     } else {
         return (
             <Tag variant="info">
                 {storForbokstav(statusetikettTekst)}{' '}
-                {refusjon.godkjentAvArbeidsgiver && formatterDato(refusjon.godkjentAvArbeidsgiver, NORSK_DATO_FORMAT)}
+                {refusjon.godkjentAvArbeidsgiver && formaterDato(refusjon.godkjentAvArbeidsgiver, NORSK_DATO_FORMAT)}
             </Tag>
         );
     }

--- a/komponenter/src/KvitteringSide/KvitteringSideMentor/SummeringBoksMentor.tsx
+++ b/komponenter/src/KvitteringSide/KvitteringSideMentor/SummeringBoksMentor.tsx
@@ -5,7 +5,7 @@ import VerticalSpacer from '~/VerticalSpacer';
 import { formatterPenger } from '~/utils/PengeUtils';
 import Boks from '~/Boks';
 import { Refusjonsgrunnlag } from '~/types/refusjon';
-import { formatterPeriode } from '~/utils';
+import { formaterPeriode } from '~/utils';
 
 type Props = {
     refusjonsgrunnlag: Refusjonsgrunnlag;
@@ -22,7 +22,7 @@ const SummeringBoksMentor: FunctionComponent<Props> = (props) => {
                 <VerticalSpacer rem={0.5} />
                 <BodyShort size="small">
                     <b>{formatterPenger(props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddsbeløp)}</b> for perioden{' '}
-                    {formatterPeriode(
+                    {formaterPeriode(
                         props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
                         props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom
                     )}{' '}

--- a/komponenter/src/KvitteringSide/KvitteringSideVTAO/InformasjonFraAvtaleVTAO.tsx
+++ b/komponenter/src/KvitteringSide/KvitteringSideVTAO/InformasjonFraAvtaleVTAO.tsx
@@ -10,7 +10,7 @@ import KIDInputValidator from '~/KIDInputValidator';
 import VerticalSpacer from '~/VerticalSpacer';
 import { Aktsomhet, Refusjonsgrunnlag, RefusjonStatus } from '~/types';
 import { InnloggetRolle } from '~/types/brukerContextType';
-import { formatterDato, formatterPeriode, NORSK_DATO_OG_TID_FORMAT } from '~/utils';
+import { formaterDato, formaterPeriode, NORSK_DATO_OG_TID_FORMAT } from '~/utils';
 import { lagId } from '~/utils/stringUtils';
 
 interface Props {
@@ -73,17 +73,17 @@ const InformasjonFraAvtalenVTAO = (props: Props) => {
             <VerticalSpacer rem={1} />
             <IkonRad>
                 <Label>Avtaleperiode: </Label>
-                <BodyShort size="small">{formatterPeriode(avtaleFom || '', avtaleTom || '')}</BodyShort>
+                <BodyShort size="small">{formaterPeriode(avtaleFom || '', avtaleTom || '')}</BodyShort>
             </IkonRad>
             <VerticalSpacer rem={1} />
             <IkonRad>
                 <Label>Tilskuddsperiode: </Label>
-                <BodyShort size="small">{formatterPeriode(tilskuddFom, tilskuddTom)}</BodyShort>
+                <BodyShort size="small">{formaterPeriode(tilskuddFom, tilskuddTom)}</BodyShort>
             </IkonRad>
             <VerticalSpacer rem={1} />
             <IkonRad>
                 <Label>Forventet utbetalt: </Label>
-                <BodyShort size="small">{formatterDato(moment(tilskuddTom).add(3, 'days').toString())}</BodyShort>
+                <BodyShort size="small">{formaterDato(moment(tilskuddTom).add(3, 'days').toString())}</BodyShort>
             </IkonRad>
             <VerticalSpacer rem={1} />
             <IkonRad>
@@ -94,7 +94,7 @@ const InformasjonFraAvtalenVTAO = (props: Props) => {
                         {bedriftKontonummerInnhentetTidspunkt ? (
                             <>
                                 {bedriftKontonummer ?? 'Ikke funnet'} (hentet{' '}
-                                {formatterDato(bedriftKontonummerInnhentetTidspunkt, NORSK_DATO_OG_TID_FORMAT)})
+                                {formaterDato(bedriftKontonummerInnhentetTidspunkt, NORSK_DATO_OG_TID_FORMAT)})
                             </>
                         ) : (
                             'Ikke oppgitt'

--- a/komponenter/src/KvitteringSide/KvitteringSideVTAO/KvitteringSideVTAO.tsx
+++ b/komponenter/src/KvitteringSide/KvitteringSideVTAO/KvitteringSideVTAO.tsx
@@ -9,7 +9,7 @@ import Statusmelding from '~/KvitteringSide/Statusmelding';
 import VerticalSpacer from '~/VerticalSpacer';
 import { Aktsomhet, Korreksjonsgrunn, Refusjon, RefusjonStatus, statusTekst } from '~/types';
 import { InnloggetBruker } from '~/types/brukerContextType';
-import { formatterDato, NORSK_DATO_FORMAT } from '~/utils';
+import { formaterDato, NORSK_DATO_FORMAT } from '~/utils';
 import { storForbokstav } from '~/utils/stringUtils';
 
 import InformasjonFraAvtalenVTAO from './InformasjonFraAvtaleVTAO';
@@ -27,7 +27,7 @@ const refusjonSendesDato = (refusjon: Refusjon): string => {
     const tidligsteDato = enDagEtterTilskuddsperioden.isBefore(morgendagensDato)
         ? morgendagensDato
         : enDagEtterTilskuddsperioden;
-    return formatterDato(tidligsteDato.toString());
+    return formaterDato(tidligsteDato.toString());
 };
 
 export const etikettForRefusjonStatus = (refusjon: Refusjon): ReactElement => {
@@ -41,14 +41,14 @@ export const etikettForRefusjonStatus = (refusjon: Refusjon): ReactElement => {
         return (
             <Tag variant="info">
                 {storForbokstav(statusetikettTekst)}{' '}
-                {refusjon.utbetaltTidspunkt && formatterDato(refusjon.utbetaltTidspunkt, NORSK_DATO_FORMAT)}
+                {refusjon.utbetaltTidspunkt && formaterDato(refusjon.utbetaltTidspunkt, NORSK_DATO_FORMAT)}
             </Tag>
         );
     } else {
         return (
             <Tag variant="info">
                 {storForbokstav(statusetikettTekst)}{' '}
-                {refusjon.godkjentAvArbeidsgiver && formatterDato(refusjon.godkjentAvArbeidsgiver, NORSK_DATO_FORMAT)}
+                {refusjon.godkjentAvArbeidsgiver && formaterDato(refusjon.godkjentAvArbeidsgiver, NORSK_DATO_FORMAT)}
             </Tag>
         );
     }

--- a/komponenter/src/KvitteringSide/KvitteringSideVTAO/SummeringBoksVTAO.tsx
+++ b/komponenter/src/KvitteringSide/KvitteringSideVTAO/SummeringBoksVTAO.tsx
@@ -1,7 +1,7 @@
 import Pengesedler from '@/asset/image/pengesedler.svg?react';
 import { Label, BodyShort } from '@navikt/ds-react';
 import { FunctionComponent } from 'react';
-import { formatterPeriode } from '../../utils/datoUtils';
+import { formaterPeriode } from '../../utils/datoUtils';
 import { Refusjonsgrunnlag } from '~/types/refusjon';
 import Boks from '~/Boks';
 import VerticalSpacer from '~/VerticalSpacer';
@@ -20,7 +20,7 @@ const SummeringBoksVTAO: FunctionComponent<{ refusjonsgrunnlag: Refusjonsgrunnla
                 <VerticalSpacer rem={0.5} />
                 <BodyShort size="small">
                     <b>{formatterPenger(tilskuddsgrunnlag.tilskuddsbeløp || 0)}</b> for perioden{' '}
-                    {formatterPeriode(tilskuddsgrunnlag.tilskuddFom, tilskuddsgrunnlag.tilskuddTom)} til kontonummer{' '}
+                    {formaterPeriode(tilskuddsgrunnlag.tilskuddFom, tilskuddsgrunnlag.tilskuddTom)} til kontonummer{' '}
                     {bedriftKontonummer}
                 </BodyShort>
                 <VerticalSpacer rem={1} />

--- a/komponenter/src/KvitteringSide/KvitteringSideVTAO/TilskuddssatsVTAO.tsx
+++ b/komponenter/src/KvitteringSide/KvitteringSideVTAO/TilskuddssatsVTAO.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import { Heading, TextField } from '@navikt/ds-react';
 import { Tilskuddsgrunnlag } from '~/types/refusjon';
-import { formatterPeriode } from '~/utils';
+import { formaterPeriode } from '~/utils';
 import VerticalSpacer from '~/VerticalSpacer';
 import Boks from '~/Boks';
 import { formatterPenger } from '~/utils/PengeUtils';
@@ -14,7 +14,7 @@ const TilskuddssatsVTAO: FunctionComponent<Props> = ({ tilskuddsgrunnlag }) => {
     return (
         <Boks variant="grønn">
             <Heading level="3" size="small">
-                Refusjon for {formatterPeriode(tilskuddsgrunnlag.tilskuddFom, tilskuddsgrunnlag.tilskuddTom)}
+                Refusjon for {formaterPeriode(tilskuddsgrunnlag.tilskuddFom, tilskuddsgrunnlag.tilskuddTom)}
             </Heading>
             <VerticalSpacer rem={1} />
             <TextField

--- a/komponenter/src/KvitteringSide/Statusmelding.tsx
+++ b/komponenter/src/KvitteringSide/Statusmelding.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 import { Alert, BodyShort } from '@navikt/ds-react';
 import { RefusjonStatus } from '~/types/status';
-import { formatterDato, NORSK_DATO_FORMAT } from '~/utils/datoUtils';
+import { formaterDato, NORSK_DATO_FORMAT } from '~/utils/datoUtils';
 
 const Statusmelding: FunctionComponent<{
     status: RefusjonStatus;
@@ -20,7 +20,7 @@ const Statusmelding: FunctionComponent<{
             if (sendtTidspunkt) {
                 return (
                     <BodyShort size="small">
-                        Refusjonskravet ble sendt {formatterDato(sendtTidspunkt, NORSK_DATO_FORMAT)} og er nå utbetalt.
+                        Refusjonskravet ble sendt {formaterDato(sendtTidspunkt, NORSK_DATO_FORMAT)} og er nå utbetalt.
                     </BodyShort>
                 );
             }

--- a/komponenter/src/LenkePanel/LenkePanel.tsx
+++ b/komponenter/src/LenkePanel/LenkePanel.tsx
@@ -2,7 +2,7 @@ import BEMHelper from '~/utils/bem';
 import { FunctionComponent } from 'react';
 import { LinkPanel, BodyShort } from '@navikt/ds-react';
 import { BegrensetRefusjon } from '~/types/refusjon';
-import { formatterDato, formatterPeriode, NORSK_DATO_FORMAT_SHORT } from '~/utils';
+import { formaterDato, formaterPeriode, NORSK_DATO_FORMAT_SHORT } from '~/utils';
 import StatusTekst from '~/StatusTekst/StatusTekst';
 import { useNavigate } from 'react-router';
 interface Props {
@@ -40,7 +40,7 @@ const LenkePanel: FunctionComponent<Props> = ({ refusjoner }) => {
                     className={cls.element('title_row_column')}
                     aria-labelledby={cls.element('periode')}
                 >
-                    {formatterPeriode(
+                    {formaterPeriode(
                         refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
                         refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom,
                         NORSK_DATO_FORMAT_SHORT
@@ -60,7 +60,7 @@ const LenkePanel: FunctionComponent<Props> = ({ refusjoner }) => {
                     className={cls.element('title_row_column')}
                     aria-labelledby={cls.element('frist-godkjenning')}
                 >
-                    {formatterDato(refusjon.fristForGodkjenning)}
+                    {formaterDato(refusjon.fristForGodkjenning)}
                 </BodyShort>
             </LinkPanel.Title>
         </LinkPanel>

--- a/komponenter/src/OversiktTabell/OversiktsTabellBody.tsx
+++ b/komponenter/src/OversiktTabell/OversiktsTabellBody.tsx
@@ -2,7 +2,7 @@ import { Table } from '@navikt/ds-react';
 import { FunctionComponent } from 'react';
 import { useNavigate } from 'react-router';
 import StatusTekst from '~/StatusTekst';
-import { formatterDato, formatterPeriode } from '~/utils';
+import { formaterDato, formaterPeriode } from '~/utils';
 import { BegrensetRefusjon } from '~/types/refusjon';
 import { kunStorForbokstav } from '~/utils/stringUtils';
 import { tiltakstypeTekstKort } from '~/types/messages';
@@ -74,7 +74,7 @@ const OversiktsTabellBody: FunctionComponent<Props> = ({ refusjoner, avtalepart 
                         />
                     </Table.DataCell>
                     <Table.DataCell textSize="small">
-                        {formatterPeriode(
+                        {formaterPeriode(
                             refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
                             refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom,
                             NORSK_DATO_FORMAT_SHORT
@@ -90,7 +90,7 @@ const OversiktsTabellBody: FunctionComponent<Props> = ({ refusjoner, avtalepart 
                         />
                     </Table.DataCell>
                     <Table.DataCell textSize="small">
-                        {skalViseGodkjenningsfrist(refusjon) ? formatterDato(refusjon.fristForGodkjenning) : ''}
+                        {skalViseGodkjenningsfrist(refusjon) ? formaterDato(refusjon.fristForGodkjenning) : ''}
                     </Table.DataCell>
                 </Table.Row>
             ))}

--- a/komponenter/src/StatusTekst/StatusTekst.tsx
+++ b/komponenter/src/StatusTekst/StatusTekst.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Tag } from '@navikt/ds-react';
 import { statusTekst } from '../types/messages';
 import { RefusjonStatus } from '../types/status';
-import { formatterDato } from '../utils/datoUtils';
+import { formaterDato } from '../utils/datoUtils';
 import { storForbokstav } from '../utils/stringUtils';
 import { Tiltak } from '../types/tiltak';
 import moment from 'moment';
@@ -26,13 +26,13 @@ const StatusTekst = (props: Props) => {
         if (props.tiltakstype === Tiltak.VTAO || props.tiltakstype === Tiltak.MENTOR) {
             return (
                 <Tag variant="info" size="small">
-                    Sendes {formatterDato(moment(props.tilskuddTom).add(1, 'days').toString())}
+                    Sendes {formaterDato(moment(props.tilskuddTom).add(1, 'days').toString())}
                 </Tag>
             );
         }
         return (
             <Tag variant="info" size="small">
-                Søk fra {formatterDato(props.tilskuddTom)}
+                Søk fra {formaterDato(props.tilskuddTom)}
             </Tag>
         );
     } else if (props.status === RefusjonStatus.UTBETALT) {

--- a/komponenter/src/StatusTekst/StatusTekst.tsx
+++ b/komponenter/src/StatusTekst/StatusTekst.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Tag } from '@navikt/ds-react';
 import { statusTekst } from '../types/messages';
 import { RefusjonStatus } from '../types/status';
-import { formaterDato } from '../utils/datoUtils';
+import { formaterDato, beregnDagenEtterOgFormater } from '../utils/datoUtils';
 import { storForbokstav } from '../utils/stringUtils';
 import { Tiltak } from '../types/tiltak';
 import moment from 'moment';
@@ -32,7 +32,7 @@ const StatusTekst = (props: Props) => {
         }
         return (
             <Tag variant="info" size="small">
-                Søk fra {formaterDato(props.tilskuddTom)}
+                Søk fra {beregnDagenEtterOgFormater(props.tilskuddTom)}
             </Tag>
         );
     } else if (props.status === RefusjonStatus.UTBETALT) {

--- a/komponenter/src/utils/boksUtils.ts
+++ b/komponenter/src/utils/boksUtils.ts
@@ -1,1 +1,0 @@
-export type Farger = 'blå' | 'grønn' | 'grå' | 'hvit';

--- a/komponenter/src/utils/datoUtils.ts
+++ b/komponenter/src/utils/datoUtils.ts
@@ -6,24 +6,26 @@ import { nb } from 'date-fns/locale';
 
 moment.locale('nb');
 
+export const NORSK_DATO_MÅNED_FORMAT = 'dd.MM';
 export const NORSK_MÅNEDÅR_FORMAT = 'yyyy/MM';
 export const NORSK_DATO_FORMAT = 'dd.MM.yyyy';
 export const NORSK_DATO_FORMAT_SHORT = 'dd.MM.yy';
 export const NORSK_DATO_OG_TID_FORMAT = 'dd.MM.yyyy HH:mm';
 
-export const formaterDato = (dato: Date | string, formatString: string = NORSK_DATO_FORMAT) => {
+export const formaterDato = (dato: Date | string, formatString: string = NORSK_DATO_FORMAT): string => {
     try {
-        return format(dato, formatString, { locale: nb });
+        return format(new Date(dato), formatString, { locale: nb });
     } catch {
-        if (dato instanceof Date) {
-            return dato.toLocaleDateString('no-nb');
-        }
-        return dato;
+        return String(dato);
     }
 };
 
-export const beregnDagenEtterOgFormater = (dato: string | Date, format: string = NORSK_DATO_FORMAT) => {
-    return formaterDato(addDays(dato, 1), format);
+export const beregnDagenEtterOgFormater = (dato: string | Date, format: string = NORSK_DATO_FORMAT): string => {
+    try {
+        return formaterDato(addDays(new Date(dato), 1), format);
+    } catch {
+        return String(dato);
+    }
 };
 
 export const formaterPeriode = (fra: string, til: string, format: string = NORSK_DATO_FORMAT) => {

--- a/komponenter/src/utils/datoUtils.ts
+++ b/komponenter/src/utils/datoUtils.ts
@@ -1,43 +1,39 @@
 import moment, { DurationInputArg2, Moment } from 'moment';
 import 'moment/dist/locale/nb';
 import { storForbokstav } from './stringUtils';
-import { format } from 'date-fns';
+import { addDays, format } from 'date-fns';
 import { nb } from 'date-fns/locale';
 
 moment.locale('nb');
 
-export const NORSK_MÅNEDÅR_FORMAT = 'YYYY/MM';
-export const NORSK_DATO_FORMAT = 'DD.MM.YYYY';
-export const NORSK_DATO_FORMAT_FN = 'dd.MM.yyyy';
-export const NORSK_DATO_FORMAT_SHORT = 'DD.MM.YY';
-export const NORSK_DATO_OG_TID_FORMAT = 'DD.MM.YYYY HH:mm';
+export const NORSK_MÅNEDÅR_FORMAT = 'yyyy/MM';
+export const NORSK_DATO_FORMAT = 'dd.MM.yyyy';
+export const NORSK_DATO_FORMAT_SHORT = 'dd.MM.yy';
+export const NORSK_DATO_OG_TID_FORMAT = 'dd.MM.yyyy HH:mm';
 
-export const formatterDato = (dato: string, format: string = NORSK_DATO_FORMAT) => {
+export const formaterDato = (dato: Date | string, formatString: string = NORSK_DATO_FORMAT) => {
     try {
-        const formattertDato = moment(dato).format(format);
-        return !formattertDato.includes('NaN') ? formattertDato : dato;
+        return format(dato, formatString, { locale: nb });
     } catch {
-        // Kunne ikke caste stringen til dato.
+        if (dato instanceof Date) {
+            return dato.toLocaleDateString('no-nb');
+        }
         return dato;
     }
 };
 
-export const formaterDatoFn = (dato: Date | string, formatString: string = NORSK_DATO_FORMAT_FN) => {
-    try {
-        return format(dato, formatString, { locale: nb });
-    } catch {
-        return 'Ugyldig dato';
-    }
+export const beregnDagenEtterOgFormater = (dato: string | Date, format: string = NORSK_DATO_FORMAT) => {
+    return formaterDato(addDays(dato, 1), format);
 };
 
-export const formatterPeriode = (fra: string, til: string, format: string = NORSK_DATO_FORMAT) => {
-    return formatterDato(fra, format) + ' – ' + formatterDato(til, format);
+export const formaterPeriode = (fra: string, til: string, format: string = NORSK_DATO_FORMAT) => {
+    return formaterDato(fra, format) + ' – ' + formaterDato(til, format);
 };
 
 export const getMåned = (dato: string) => {
     try {
-        const formattertDato = moment(dato).format('MMMM');
-        return !formattertDato.includes('NaN') ? storForbokstav(formattertDato) : dato;
+        const formatertDato = moment(dato).format('MMMM');
+        return !formatertDato.includes('NaN') ? storForbokstav(formatertDato) : dato;
     } catch {
         // Kunne ikke caste stringen til dato.
         return dato;

--- a/saksbehandler/src/KorreksjonKvitteringSide/KorreksjonSummeringsBoks.tsx
+++ b/saksbehandler/src/KorreksjonKvitteringSide/KorreksjonSummeringsBoks.tsx
@@ -4,7 +4,7 @@ import VerticalSpacer from '~/VerticalSpacer';
 import { formatterPenger } from '../utils/PengeUtils';
 import { BodyShort, Label } from '@navikt/ds-react';
 import { Refusjonsgrunnlag } from '~/types/refusjon';
-import { formatterPeriode } from '~/utils';
+import { formaterPeriode } from '~/utils';
 import Boks from '~/Boks';
 
 const KorreksjonSummeringBoks: FunctionComponent<{ refusjonsgrunnlag: Refusjonsgrunnlag }> = ({
@@ -24,7 +24,7 @@ const KorreksjonSummeringBoks: FunctionComponent<{ refusjonsgrunnlag: Refusjonsg
                                 Dere skylder{' '}
                                 <b>{formatterPenger(Math.abs(refusjonsgrunnlag.beregning?.refusjonsbeløp || 0))}</b> for
                                 perioden{' '}
-                                {formatterPeriode(
+                                {formaterPeriode(
                                     refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
                                     refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom
                                 )}
@@ -39,7 +39,7 @@ const KorreksjonSummeringBoks: FunctionComponent<{ refusjonsgrunnlag: Refusjonsg
                             <VerticalSpacer rem={0.5} />
                             <BodyShort size="small">
                                 <b>{formatterPenger(refusjonsgrunnlag.beregning?.refusjonsbeløp || 0)}</b> for perioden{' '}
-                                {formatterPeriode(
+                                {formaterPeriode(
                                     refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
                                     refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom
                                 )}{' '}

--- a/saksbehandler/src/KorreksjonKvitteringSideVTAO/KorreksjonSummeringBoksVTAO.tsx
+++ b/saksbehandler/src/KorreksjonKvitteringSideVTAO/KorreksjonSummeringBoksVTAO.tsx
@@ -2,7 +2,7 @@ import Pengesedler from '@/asset/image/pengesedler.svg?react';
 import React, { FunctionComponent } from 'react';
 import { BodyShort } from '@navikt/ds-react';
 import { Tilskuddsgrunnlag } from '~/types/refusjon';
-import { formatterPeriode } from '~/utils';
+import { formaterPeriode } from '~/utils';
 import VerticalSpacer from '~/VerticalSpacer';
 import { formatterPenger } from '@/utils/PengeUtils';
 import Boks from '~/Boks';
@@ -18,7 +18,7 @@ const KorreksjonSummeringBoksVTAO: FunctionComponent<{ tilskuddsgrunnlag: Tilsku
             <VerticalSpacer rem={0.5} />
             <BodyShort size="small">
                 Dere skylder <b>{formatterPenger(Math.abs(tilskuddsgrunnlag.tilskuddsbeløp || 0))}</b> for perioden{' '}
-                {formatterPeriode(tilskuddsgrunnlag.tilskuddFom, tilskuddsgrunnlag.tilskuddTom)} Beløpet vil
+                {formaterPeriode(tilskuddsgrunnlag.tilskuddFom, tilskuddsgrunnlag.tilskuddTom)} Beløpet vil
                 tilbakekreves.
             </BodyShort>
         </Boks>

--- a/saksbehandler/src/refusjon/Hendelseslogg/Hendelseslogg.tsx
+++ b/saksbehandler/src/refusjon/Hendelseslogg/Hendelseslogg.tsx
@@ -11,7 +11,7 @@ import { Nettressurs, Status } from '~/nettressurs';
 import BEMHelper from '~/utils/bem';
 import { hendelseTekst } from '~/types/messages';
 import { Hendelse, HendelseType } from '~/types/refusjon';
-import { formatterDato, NORSK_DATO_OG_TID_FORMAT } from '~/utils';
+import { formaterDato, NORSK_DATO_OG_TID_FORMAT } from '~/utils';
 import { storForbokstav } from '~/utils/stringUtils';
 
 type Props = {
@@ -133,10 +133,10 @@ const HendelsesLogg: FunctionComponent<Props> = (props) => {
                                         <Table.Row key={varsel.id} role="row">
                                             <Table.DataCell role="cell" aria-labelledby="tidspunkt">
                                                 <UtgråetTekst
-                                                    title={formatterDato(varsel.tidspunkt)}
+                                                    title={formaterDato(varsel.tidspunkt)}
                                                     grå={varsel.skjules}
                                                 >
-                                                    {formatterDato(varsel.tidspunkt, NORSK_DATO_OG_TID_FORMAT)}
+                                                    {formaterDato(varsel.tidspunkt, NORSK_DATO_OG_TID_FORMAT)}
                                                 </UtgråetTekst>
                                             </Table.DataCell>
                                             <Table.DataCell
@@ -149,7 +149,7 @@ const HendelsesLogg: FunctionComponent<Props> = (props) => {
                                                     <HendelseIkon hendelse={varsel.event as HendelseType} />
                                                     <span style={{ marginLeft: '0.2rem' }}>
                                                         <UtgråetTekst
-                                                            title={formatterDato(varsel.tidspunkt)}
+                                                            title={formaterDato(varsel.tidspunkt)}
                                                             grå={varsel.skjules}
                                                         >
                                                             {hendelseVarselTekst(varsel)}
@@ -161,7 +161,7 @@ const HendelsesLogg: FunctionComponent<Props> = (props) => {
                                                 <div className={'ikonRad'} aria-labelledby="varsel">
                                                     <span style={{ marginRight: '0.5rem' }} aria-hidden="true">
                                                         <UtgråetTekst
-                                                            title={formatterDato(varsel.tidspunkt)}
+                                                            title={formaterDato(varsel.tidspunkt)}
                                                             grå={varsel.skjules}
                                                         >
                                                             {storForbokstav(varsel.utførtAv ? varsel.utførtAv : '')}

--- a/saksbehandler/src/refusjon/KvitteringSide/KvitteringSide.tsx
+++ b/saksbehandler/src/refusjon/KvitteringSide/KvitteringSide.tsx
@@ -17,7 +17,7 @@ import VerticalSpacer from '~/VerticalSpacer';
 import { Aktsomhet, RefusjonStatus, statusTekst, tiltakstypeTekst, Korreksjonsgrunn, Refusjon } from '~/types';
 import { Feature } from '@/featureToggles/features';
 import { InnloggetBruker } from '~/types/brukerContextType';
-import { formatterDato, NORSK_DATO_OG_TID_FORMAT } from '~/utils';
+import { formaterDato, NORSK_DATO_OG_TID_FORMAT } from '~/utils';
 import { storForbokstav } from '~/utils/stringUtils';
 import { useFeatureToggles } from '@/featureToggles/FeatureToggleProvider';
 
@@ -30,8 +30,7 @@ const etikettForRefusjonStatus = (refusjon: Refusjon): ReactElement => {
     return (
         <Tag variant="info">
             {storForbokstav(statusTekst[refusjon.status])}{' '}
-            {refusjon.godkjentAvArbeidsgiver &&
-                formatterDato(refusjon.godkjentAvArbeidsgiver, NORSK_DATO_OG_TID_FORMAT)}
+            {refusjon.godkjentAvArbeidsgiver && formaterDato(refusjon.godkjentAvArbeidsgiver, NORSK_DATO_OG_TID_FORMAT)}
         </Tag>
     );
 };

--- a/saksbehandler/src/refusjon/RefusjonSide/HarTattStillingTilAlleInnteksLinjerNyLabel.tsx
+++ b/saksbehandler/src/refusjon/RefusjonSide/HarTattStillingTilAlleInnteksLinjerNyLabel.tsx
@@ -2,7 +2,7 @@ import { Label } from '@navikt/ds-react';
 import { formatterPenger } from '@/utils/PengeUtils';
 import { FunctionComponent } from 'react';
 import { Refusjonsgrunnlag } from '~/types/refusjon';
-import { formaterPeriode } from '~/utils';
+import { formaterPeriode, NORSK_DATO_MÅNED_FORMAT } from '~/utils';
 import { tiltakstypeTekst } from '~/types/messages';
 
 interface Props {
@@ -19,7 +19,7 @@ const InntekterFraTiltaketSvarNyLabel: FunctionComponent<Props> = ({ refusjonsgr
     const periode = formaterPeriode(
         refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
         refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom,
-        'DD.MM'
+        NORSK_DATO_MÅNED_FORMAT
     );
 
     return (

--- a/saksbehandler/src/refusjon/RefusjonSide/HarTattStillingTilAlleInnteksLinjerNyLabel.tsx
+++ b/saksbehandler/src/refusjon/RefusjonSide/HarTattStillingTilAlleInnteksLinjerNyLabel.tsx
@@ -2,7 +2,7 @@ import { Label } from '@navikt/ds-react';
 import { formatterPenger } from '@/utils/PengeUtils';
 import { FunctionComponent } from 'react';
 import { Refusjonsgrunnlag } from '~/types/refusjon';
-import { formatterPeriode } from '~/utils';
+import { formaterPeriode } from '~/utils';
 import { tiltakstypeTekst } from '~/types/messages';
 
 interface Props {
@@ -16,7 +16,7 @@ const InntekterFraTiltaketSvarNyLabel: FunctionComponent<Props> = ({ refusjonsgr
         .map((el) => el.beløp)
         .reduce((el, el2) => el + el2, 0);
 
-    const periode = formatterPeriode(
+    const periode = formaterPeriode(
         refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
         refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom,
         'DD.MM'

--- a/saksbehandler/src/refusjon/RefusjonSide/HarTattStillingTilAlleInntektsLinjerNy.tsx
+++ b/saksbehandler/src/refusjon/RefusjonSide/HarTattStillingTilAlleInntektsLinjerNy.tsx
@@ -7,7 +7,7 @@ import InntekterOpptjentIPeriodeTabell from './InntekterOpptjentIPeriodeTabell';
 import { BodyShort, Heading, Label } from '@navikt/ds-react';
 import { Refusjonsgrunnlag } from '~/types/refusjon';
 import { formatterPenger } from '@/utils/PengeUtils';
-import { formatterPeriode, månedsNavn } from '~/utils';
+import { formaterPeriode, månedsNavn } from '~/utils';
 
 import styles from './InntekterFraTiltaketSpørsmål.module.less';
 
@@ -36,7 +36,7 @@ const HarTattStillingTilAlleInntektsLinjerNy: FunctionComponent<Props> = (props)
             <div className={styles.gronnBoks}>
                 <Heading size="small">
                     Inntekter som refunderes for{' '}
-                    {formatterPeriode(
+                    {formaterPeriode(
                         props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
                         props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom
                     )}

--- a/saksbehandler/src/refusjon/RefusjonSide/InformasjonFraAvtalen.tsx
+++ b/saksbehandler/src/refusjon/RefusjonSide/InformasjonFraAvtalen.tsx
@@ -7,7 +7,7 @@ import Rad from '@/komponenter/Rad/Rad';
 import VerticalSpacer from '~/VerticalSpacer';
 import { Aktsomhet, tiltakstypeTekst } from '~/types';
 import { Tilskuddsgrunnlag } from '~/types/refusjon';
-import { formatterDato, formatterPeriode, NORSK_DATO_OG_TID_FORMAT } from '~/utils';
+import { formaterDato, formaterPeriode, NORSK_DATO_OG_TID_FORMAT } from '~/utils';
 import { formatterPenger } from '@/utils/PengeUtils';
 
 interface Props {
@@ -64,16 +64,16 @@ const InformasjonFraAvtalen = (props: Props) => {
             <Rad>
                 <Label>Periode: </Label>
                 <BodyShort size="small">
-                    {formatterPeriode(tilskuddsgrunnlag.tilskuddFom, tilskuddsgrunnlag.tilskuddTom)}
+                    {formaterPeriode(tilskuddsgrunnlag.tilskuddFom, tilskuddsgrunnlag.tilskuddTom)}
                 </BodyShort>
             </Rad>
             {fristForGodkjenning && (
                 <Rad>
                     <Label>Frist: </Label>
                     <BodyShort size="small">
-                        {formatterDato(fristForGodkjenning)}
+                        {formaterDato(fristForGodkjenning)}
                         {forrigeFristForGodkjenning
-                            ? `  (tidligere frist: ${formatterDato(forrigeFristForGodkjenning)})`
+                            ? `  (tidligere frist: ${formaterDato(forrigeFristForGodkjenning)})`
                             : ''}
                     </BodyShort>
                 </Rad>
@@ -88,7 +88,7 @@ const InformasjonFraAvtalen = (props: Props) => {
                     {bedriftKontonummerInnhentetTidspunkt ? (
                         <>
                             {bedriftKontonummer ?? 'Ikke funnet'} (hentet{' '}
-                            {formatterDato(bedriftKontonummerInnhentetTidspunkt, NORSK_DATO_OG_TID_FORMAT)})
+                            {formaterDato(bedriftKontonummerInnhentetTidspunkt, NORSK_DATO_OG_TID_FORMAT)})
                         </>
                     ) : (
                         'Ikke oppgitt'

--- a/saksbehandler/src/refusjon/RefusjonSide/InntekterFraAMeldingen/InntektsMeldingHeader.tsx
+++ b/saksbehandler/src/refusjon/RefusjonSide/InntekterFraAMeldingen/InntektsMeldingHeader.tsx
@@ -1,7 +1,7 @@
 import { BodyShort, Heading } from '@navikt/ds-react';
 import { FunctionComponent } from 'react';
 import { Refusjonsgrunnlag } from '~/types/refusjon';
-import { formatterDato, månedsNavn, NORSK_DATO_OG_TID_FORMAT } from '~/utils';
+import { formaterDato, månedsNavn, NORSK_DATO_OG_TID_FORMAT } from '~/utils';
 import BEMHelper from '~/utils/bem';
 
 interface Properties {
@@ -34,7 +34,7 @@ const InntektsMeldingHeader: FunctionComponent<Properties> = ({
                 {refusjonsgrunnlag.inntektsgrunnlag && (
                     <BodyShort size="small">
                         Sist hentet:{' '}
-                        {formatterDato(refusjonsgrunnlag.inntektsgrunnlag.innhentetTidspunkt, NORSK_DATO_OG_TID_FORMAT)}
+                        {formaterDato(refusjonsgrunnlag.inntektsgrunnlag.innhentetTidspunkt, NORSK_DATO_OG_TID_FORMAT)}
                     </BodyShort>
                 )}
             </Heading>

--- a/saksbehandler/src/refusjon/RefusjonSide/InntekterFraAMeldingen/inntektsmeldingTabell/InntektsmeldingTabellBody.tsx
+++ b/saksbehandler/src/refusjon/RefusjonSide/InntekterFraAMeldingen/inntektsmeldingTabell/InntektsmeldingTabellBody.tsx
@@ -5,7 +5,7 @@ import { inntektBeskrivelse } from '../InntekterFraAMeldingen';
 import InntektValg from './InntektValg';
 import sortBy from 'lodash.sortby';
 import { Inntektslinje } from '~/types/refusjon';
-import { formatterDato, formatterPeriode, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
+import { formaterDato, formaterPeriode, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
 
 type Props = {
     inntektslinjer: Inntektslinje[];
@@ -28,10 +28,10 @@ const InntektsmeldingTabellBody: FunctionComponent<Props> = (props) => {
             ).map((inntekt) => (
                 <tr key={inntekt.id}>
                     <td>{inntektBeskrivelse(inntekt.beskrivelse)}</td>
-                    <td>{formatterDato(inntekt.måned, NORSK_MÅNEDÅR_FORMAT)}</td>
+                    <td>{formaterDato(inntekt.måned, NORSK_MÅNEDÅR_FORMAT)}</td>
                     <td>
                         {inntekt.opptjeningsperiodeFom && inntekt.opptjeningsperiodeTom ? (
-                            formatterPeriode(inntekt.opptjeningsperiodeFom, inntekt.opptjeningsperiodeTom, 'DD.MM')
+                            formaterPeriode(inntekt.opptjeningsperiodeFom, inntekt.opptjeningsperiodeTom, 'DD.MM')
                         ) : (
                             <em>Ikke rapportert opptjenings&shy;periode</em>
                         )}

--- a/saksbehandler/src/refusjon/RefusjonSide/InntekterFraAMeldingen/inntektsmeldingTabell/InntektsmeldingTabellBody.tsx
+++ b/saksbehandler/src/refusjon/RefusjonSide/InntekterFraAMeldingen/inntektsmeldingTabell/InntektsmeldingTabellBody.tsx
@@ -5,7 +5,7 @@ import { inntektBeskrivelse } from '../InntekterFraAMeldingen';
 import InntektValg from './InntektValg';
 import sortBy from 'lodash.sortby';
 import { Inntektslinje } from '~/types/refusjon';
-import { formaterDato, formaterPeriode, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
+import { formaterDato, formaterPeriode, NORSK_DATO_MÅNED_FORMAT, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
 
 type Props = {
     inntektslinjer: Inntektslinje[];
@@ -31,7 +31,11 @@ const InntektsmeldingTabellBody: FunctionComponent<Props> = (props) => {
                     <td>{formaterDato(inntekt.måned, NORSK_MÅNEDÅR_FORMAT)}</td>
                     <td>
                         {inntekt.opptjeningsperiodeFom && inntekt.opptjeningsperiodeTom ? (
-                            formaterPeriode(inntekt.opptjeningsperiodeFom, inntekt.opptjeningsperiodeTom, 'DD.MM')
+                            formaterPeriode(
+                                inntekt.opptjeningsperiodeFom,
+                                inntekt.opptjeningsperiodeTom,
+                                NORSK_DATO_MÅNED_FORMAT
+                            )
                         ) : (
                             <em>Ikke rapportert opptjenings&shy;periode</em>
                         )}

--- a/saksbehandler/src/refusjon/RefusjonSide/InntekterFraAmeldingenGammel.tsx
+++ b/saksbehandler/src/refusjon/RefusjonSide/InntekterFraAmeldingenGammel.tsx
@@ -5,7 +5,13 @@ import VerticalSpacer from '~/VerticalSpacer';
 import sortBy from 'lodash.sortby';
 import { Alert, BodyShort, Heading } from '@navikt/ds-react';
 import { Inntektsgrunnlag } from '~/types/refusjon';
-import { formaterDato, formaterPeriode, NORSK_DATO_OG_TID_FORMAT, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
+import {
+    formaterDato,
+    formaterPeriode,
+    NORSK_DATO_MÅNED_FORMAT,
+    NORSK_DATO_OG_TID_FORMAT,
+    NORSK_MÅNEDÅR_FORMAT,
+} from '~/utils';
 import { formatterPenger } from '@/utils/PengeUtils';
 import { lønnsbeskrivelseTekst } from '~/types/messages';
 
@@ -79,7 +85,7 @@ const InntekterFraAMeldingenGammel: FunctionComponent<{
                                                 formaterPeriode(
                                                     inntekt.opptjeningsperiodeFom,
                                                     inntekt.opptjeningsperiodeTom,
-                                                    'DD.MM'
+                                                    NORSK_DATO_MÅNED_FORMAT
                                                 )
                                             ) : (
                                                 <em>Ikke rapportert opptjenings&shy;periode</em>

--- a/saksbehandler/src/refusjon/RefusjonSide/InntekterFraAmeldingenGammel.tsx
+++ b/saksbehandler/src/refusjon/RefusjonSide/InntekterFraAmeldingenGammel.tsx
@@ -5,7 +5,7 @@ import VerticalSpacer from '~/VerticalSpacer';
 import sortBy from 'lodash.sortby';
 import { Alert, BodyShort, Heading } from '@navikt/ds-react';
 import { Inntektsgrunnlag } from '~/types/refusjon';
-import { formatterDato, formatterPeriode, NORSK_DATO_OG_TID_FORMAT, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
+import { formaterDato, formaterPeriode, NORSK_DATO_OG_TID_FORMAT, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
 import { formatterPenger } from '@/utils/PengeUtils';
 import { lønnsbeskrivelseTekst } from '~/types/messages';
 
@@ -43,8 +43,7 @@ const InntekterFraAMeldingenGammel: FunctionComponent<{
                 </Heading>
                 {props.inntektsgrunnlag && (
                     <BodyShort size="small">
-                        Sist hentet:{' '}
-                        {formatterDato(props.inntektsgrunnlag.innhentetTidspunkt, NORSK_DATO_OG_TID_FORMAT)}
+                        Sist hentet: {formaterDato(props.inntektsgrunnlag.innhentetTidspunkt, NORSK_DATO_OG_TID_FORMAT)}
                     </BodyShort>
                 )}
             </div>
@@ -73,11 +72,11 @@ const InntekterFraAMeldingenGammel: FunctionComponent<{
                                 ).map((inntekt) => (
                                     <tr key={inntekt.id}>
                                         <td>{inntektBeskrivelse(inntekt.beskrivelse)}</td>
-                                        <td>{formatterDato(inntekt.måned, NORSK_MÅNEDÅR_FORMAT)}</td>
+                                        <td>{formaterDato(inntekt.måned, NORSK_MÅNEDÅR_FORMAT)}</td>
 
                                         <td>
                                             {inntekt.opptjeningsperiodeFom && inntekt.opptjeningsperiodeTom ? (
-                                                formatterPeriode(
+                                                formaterPeriode(
                                                     inntekt.opptjeningsperiodeFom,
                                                     inntekt.opptjeningsperiodeTom,
                                                     'DD.MM'

--- a/saksbehandler/src/refusjon/RefusjonSide/InntekterFraTiltaketSpørsmål.tsx
+++ b/saksbehandler/src/refusjon/RefusjonSide/InntekterFraTiltaketSpørsmål.tsx
@@ -7,7 +7,7 @@ import { BodyShort, Heading, Label, Radio, RadioGroup, TextField } from '@navikt
 import { Refusjonsgrunnlag } from '~/types/refusjon';
 import { endreBruttolønn, useHentKorreksjon } from '@/services/rest-service';
 import { formatterPenger } from '@/utils/PengeUtils';
-import { formatterPeriode, månedsNavn } from '~/utils';
+import { formaterPeriode, månedsNavn } from '~/utils';
 import { sumInntekterOpptjentIPeriode } from '@/utils/inntekterUtils';
 import { tiltakstypeTekst } from '~/types/messages';
 
@@ -24,7 +24,7 @@ const InntekterFraTiltaketSpørsmål: FunctionComponent<{ refusjonsgrunnlag: Ref
     const [endretBruttoLønn, setEndretBruttoLønn] = useState(refusjonsgrunnlag.endretBruttoLønn);
 
     const refusjonNummer = `${tilskuddsgrunnlag.avtaleNr}-${tilskuddsgrunnlag.løpenummer}`;
-    const periode = formatterPeriode(
+    const periode = formaterPeriode(
         korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
         korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom,
         'DD.MM'
@@ -59,7 +59,7 @@ const InntekterFraTiltaketSpørsmål: FunctionComponent<{ refusjonsgrunnlag: Ref
         <div className={styles.gronnBoks}>
             <Heading size="small">
                 Inntekter som skal refunderes for{' '}
-                {formatterPeriode(tilskuddsgrunnlag.tilskuddFom, tilskuddsgrunnlag.tilskuddTom)}
+                {formaterPeriode(tilskuddsgrunnlag.tilskuddFom, tilskuddsgrunnlag.tilskuddTom)}
             </Heading>
             <VerticalSpacer rem={1} />
             <BodyShort size="small">

--- a/saksbehandler/src/refusjon/RefusjonSide/InntekterFraTiltaketSpørsmål.tsx
+++ b/saksbehandler/src/refusjon/RefusjonSide/InntekterFraTiltaketSpørsmål.tsx
@@ -7,7 +7,7 @@ import { BodyShort, Heading, Label, Radio, RadioGroup, TextField } from '@navikt
 import { Refusjonsgrunnlag } from '~/types/refusjon';
 import { endreBruttolønn, useHentKorreksjon } from '@/services/rest-service';
 import { formatterPenger } from '@/utils/PengeUtils';
-import { formaterPeriode, månedsNavn } from '~/utils';
+import { formaterPeriode, månedsNavn, NORSK_DATO_MÅNED_FORMAT } from '~/utils';
 import { sumInntekterOpptjentIPeriode } from '@/utils/inntekterUtils';
 import { tiltakstypeTekst } from '~/types/messages';
 
@@ -27,7 +27,7 @@ const InntekterFraTiltaketSpørsmål: FunctionComponent<{ refusjonsgrunnlag: Ref
     const periode = formaterPeriode(
         korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
         korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom,
-        'DD.MM'
+        NORSK_DATO_MÅNED_FORMAT
     );
 
     if (!refusjonsgrunnlag.inntektsgrunnlag) {

--- a/saksbehandler/src/refusjon/RefusjonSide/InntekterOpptjentIPeriodeTabell.tsx
+++ b/saksbehandler/src/refusjon/RefusjonSide/InntekterOpptjentIPeriodeTabell.tsx
@@ -5,7 +5,7 @@ import sortBy from 'lodash.sortby';
 
 import { inntektBeskrivelse } from './InntekterFraAMeldingen/InntekterFraAMeldingen';
 import { Inntektslinje } from '~/types/refusjon';
-import { formatterDato, formatterPeriode, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
+import { formaterDato, formaterPeriode, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
 
 import styles from './InntekterOpptjentIPeriodeTabell.module.less';
 
@@ -44,10 +44,10 @@ const InntekterOpptjentIPeriodeTabell: FunctionComponent<Props> = (props) => {
                     {sorterInntektslinjer(inntekterHuketAvForOpptjentIPeriode).map((inntekt) => (
                         <tr key={inntekt.id}>
                             <td>{inntektBeskrivelse(inntekt.beskrivelse)}</td>
-                            <td>{formatterDato(inntekt.måned, NORSK_MÅNEDÅR_FORMAT)}</td>
+                            <td>{formaterDato(inntekt.måned, NORSK_MÅNEDÅR_FORMAT)}</td>
                             <td>
                                 {inntekt.opptjeningsperiodeFom && inntekt.opptjeningsperiodeTom ? (
-                                    formatterPeriode(
+                                    formaterPeriode(
                                         inntekt.opptjeningsperiodeFom,
                                         inntekt.opptjeningsperiodeTom,
                                         'DD.MM'

--- a/saksbehandler/src/refusjon/RefusjonSide/InntekterOpptjentIPeriodeTabell.tsx
+++ b/saksbehandler/src/refusjon/RefusjonSide/InntekterOpptjentIPeriodeTabell.tsx
@@ -5,7 +5,7 @@ import sortBy from 'lodash.sortby';
 
 import { inntektBeskrivelse } from './InntekterFraAMeldingen/InntekterFraAMeldingen';
 import { Inntektslinje } from '~/types/refusjon';
-import { formaterDato, formaterPeriode, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
+import { formaterDato, formaterPeriode, NORSK_DATO_MÅNED_FORMAT, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
 
 import styles from './InntekterOpptjentIPeriodeTabell.module.less';
 
@@ -50,7 +50,7 @@ const InntekterOpptjentIPeriodeTabell: FunctionComponent<Props> = (props) => {
                                     formaterPeriode(
                                         inntekt.opptjeningsperiodeFom,
                                         inntekt.opptjeningsperiodeTom,
-                                        'DD.MM'
+                                        NORSK_DATO_MÅNED_FORMAT
                                     )
                                 ) : (
                                     <em>Ikke rapportert opptjenings&shy;periode</em>

--- a/saksbehandler/src/refusjon/RefusjonSide/Refusjon.tsx
+++ b/saksbehandler/src/refusjon/RefusjonSide/Refusjon.tsx
@@ -13,7 +13,7 @@ import MerkForUnntakOmInntekterToMånederFrem from '@/refusjon/MerkForUnntakOmIn
 import TilbakeTilOversikt from '@/komponenter/tilbake-til-oversikt/TilbakeTilOversikt';
 import VerticalSpacer from '~/VerticalSpacer';
 import { Tiltak, Korreksjonsgrunn, RefusjonStatus, BrukerContextType } from '~/types';
-import { formatterDato } from '~/utils';
+import { beregnDagenEtterOgFormater, formaterDato } from '~/utils';
 import { opprettKorreksjonsutkast, useHentRefusjon, useRefusjonKreverAktsomhet } from '@/services/rest-service';
 import { useInnloggetBruker } from '@/bruker/BrukerContext';
 
@@ -115,7 +115,7 @@ const Komponent: FunctionComponent = () => {
                         aktsomhet={aktsomhet}
                         refusjon={refusjon}
                         advarselType="info"
-                        feiltekst={`Du kan søke om refusjon fra ${formatterDato(
+                        feiltekst={`Du kan søke om refusjon fra ${beregnDagenEtterOgFormater(
                             refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom
                         )} når perioden er over.`}
                     />
@@ -150,7 +150,7 @@ const Komponent: FunctionComponent = () => {
                         aktsomhet={aktsomhet}
                         refusjon={refusjon}
                         advarselType="warning"
-                        feiltekst={`Fristen for å søke om refusjon for denne perioden gikk ut ${formatterDato(
+                        feiltekst={`Fristen for å søke om refusjon for denne perioden gikk ut ${formaterDato(
                             refusjon.fristForGodkjenning
                         )}. Fristen kan ikke forlenges etter at den er utgått.`}
                     />

--- a/saksbehandler/src/refusjon/RefusjonSide/SummeringBoks.tsx
+++ b/saksbehandler/src/refusjon/RefusjonSide/SummeringBoks.tsx
@@ -5,7 +5,7 @@ import VerticalSpacer from '~/VerticalSpacer';
 import { BodyShort, Label } from '@navikt/ds-react';
 import { Refusjonsgrunnlag, Tilskuddsgrunnlag } from '~/types/refusjon';
 import { formatterPenger } from '@/utils/PengeUtils';
-import { formatterPeriode } from '~/utils';
+import { formaterPeriode } from '~/utils';
 
 import styles from './SummeringBoks.module.less';
 
@@ -35,7 +35,7 @@ const SummeringBoks: FunctionComponent<Props> = (props) => {
                     <VerticalSpacer rem={0.5} />
                     <BodyShort size="small">
                         <b>{formatterPenger(props.refusjonsgrunnlag.beregning?.refusjonsbeløp || 0)}</b> for perioden{' '}
-                        {formatterPeriode(
+                        {formaterPeriode(
                             props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
                             props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom
                         )}{' '}
@@ -50,7 +50,7 @@ const SummeringBoks: FunctionComponent<Props> = (props) => {
                     <BodyShort size="small">
                         <Label>
                             Refusjonen er godtatt med {formatterPenger(0)} for perioden{' '}
-                            {formatterPeriode(
+                            {formaterPeriode(
                                 props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
                                 props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom
                             )}
@@ -95,7 +95,7 @@ const SummeringBoks: FunctionComponent<Props> = (props) => {
                         Dere skylder{' '}
                         <b>{formatterPenger(Math.abs(props.refusjonsgrunnlag.beregning?.refusjonsbeløp || 0))}</b> for
                         perioden{' '}
-                        {formatterPeriode(
+                        {formaterPeriode(
                             props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
                             props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom
                         )}

--- a/saksbehandler/src/refusjon/RefusjonSide/SummeringBoksNullbeløp.tsx
+++ b/saksbehandler/src/refusjon/RefusjonSide/SummeringBoksNullbeløp.tsx
@@ -4,7 +4,7 @@ import { FunctionComponent } from 'react';
 import Pengesedler from '@/asset/image/pengesedler.svg?react';
 import { Refusjonsgrunnlag } from '~/types/refusjon';
 import { formatterPenger } from '@/utils/PengeUtils';
-import { formatterPeriode } from '~/utils';
+import { formaterPeriode } from '~/utils';
 
 import styles from './SummeringBoksNullbeløp.module.less';
 
@@ -20,7 +20,7 @@ const SummeringBoksNullbeløp: FunctionComponent<Props> = (props) => {
             </div>
             <Label>
                 Refusjonen er godtatt med {formatterPenger(0)} for perioden{' '}
-                {formatterPeriode(
+                {formaterPeriode(
                     props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
                     props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom
                 )}

--- a/saksbehandler/src/refusjon/RefusjonSide/UtregningsradHvaInngårIDette.tsx
+++ b/saksbehandler/src/refusjon/RefusjonSide/UtregningsradHvaInngårIDette.tsx
@@ -4,7 +4,7 @@ import { formatterPenger } from '../../utils/PengeUtils';
 
 import { inntektBeskrivelse } from './InntekterFraAMeldingen/InntekterFraAMeldingen';
 import { Inntektslinje, Tilskuddsgrunnlag } from '~/types/refusjon';
-import { formatterDato, getMåned, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
+import { formaterDato, getMåned, NORSK_MÅNEDÅR_FORMAT } from '~/utils';
 
 type Props = {
     inntekter: Inntektslinje[];
@@ -37,9 +37,7 @@ const UtregningsradHvaInngårIDette: FunctionComponent<Props> = (props) => {
                                     <Table.DataCell style={{ maxWidth: '10rem' }}>
                                         {inntektBeskrivelse(inntekt.beskrivelse)}
                                     </Table.DataCell>
-                                    <Table.DataCell>
-                                        {formatterDato(inntekt.måned, NORSK_MÅNEDÅR_FORMAT)}
-                                    </Table.DataCell>
+                                    <Table.DataCell>{formaterDato(inntekt.måned, NORSK_MÅNEDÅR_FORMAT)}</Table.DataCell>
                                     <Table.DataCell>{formatterPenger(inntekt.beløp)}</Table.DataCell>
                                     <Table.DataCell>
                                         {erFerietrekkForAnnenMåned && (


### PR DESCRIPTION
* Enderer datoen i tekst slik at søknadsstart er dagen etter forrige periode er over
* Oppdaterer hjelpefunksjoner for Datoer til å bruke date-fns
* Fikser formatter -> formater
* Inliner `BoxUtils`, som bare var brukt i en fil. 