### PR TITLE
Kort-versjon av navn for fireårig lønnstilskudd

### DIFF
--- a/komponenter/src/types/messages.ts
+++ b/komponenter/src/types/messages.ts
@@ -14,6 +14,7 @@ export const tiltakstypeTekst: { [key in Tiltak]: string } = {
 export const tiltakstypeTekstKort: { [key in Tiltak]: string } = {
     ...tiltakstypeTekst,
     VTAO: 'VTA-O',
+    FIREARIG_LONNSTILSKUDD: 'fireårig lønnstilskudd',
 };
 
 export const statusTekst: { [key in RefusjonStatus]: string } = {


### PR DESCRIPTION
I tabellvisningene har vi lyst til å ha litt kortere navn for denne tiltakstypen, fordi den fulle teksten ender opp med å spenne over flere linjer.

<table>
<tr><th>Før</th><th>Etter</th></tr>
<tr><td>
<img width="1523" height="725" alt="image" src="https://github.com/user-attachments/assets/def13c71-84c8-43e9-b0e3-0f76eece5f1b" />
</td><td>
<img width="1501" height="547" alt="image" src="https://github.com/user-attachments/assets/1a5bdc89-9328-4ffe-a99d-a097f2e3b854" />
</td></tr>
</table>