### PR TITLE
fix. vis riktig tiltakstype i tekst

### DIFF
--- a/arbeidsgiver/src/refusjon/RefusjonSide/RefusjonIngress.tsx
+++ b/arbeidsgiver/src/refusjon/RefusjonSide/RefusjonIngress.tsx
@@ -36,7 +36,7 @@ const RefusjonIngress: FunctionComponent<Properties> = ({ refusjon }: PropsWithC
                     oppdateres i ditt lønnssystem.
                 </EksternLenke>
                 Feriepenger, innskudd obligatorisk tjenestepensjon, arbeidsgiveravgiften og lønnstilskuddsprosenten er
-                hentet fra avtalen om midlertidig lønnstilskudd.
+                hentet fra avtalen om {tiltakstypeTekst[refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype]}.
             </BodyShort>
             <BodyShort size="small" className={cls.element('ingress-text-refusjon')}>
                 Siste frist for å sende inn kravet er senest to måneder etter at perioden er over. Hvis fristen ikke

--- a/saksbehandler/src/refusjon/RefusjonSide/RefusjonSide.tsx
+++ b/saksbehandler/src/refusjon/RefusjonSide/RefusjonSide.tsx
@@ -57,7 +57,7 @@ const RefusjonSide = (props: Props) => {
                     oppdateres i A-meldingen hos Altinn.
                 </EksternLenke>
                 Feriepenger, innskudd obligatorisk tjenestepensjon, arbeidsgiveravgiften og lønnstilskuddsprosenten er
-                hentet fra avtalen om midlertidig lønnstilskudd.
+                hentet fra avtalen om {tiltakstypeTekst[refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype]}.
             </BodyShort>
             <VerticalSpacer rem={2} />
             <InformasjonFraAvtalen


### PR DESCRIPTION
Erstattet '...hentet fra avtalen om midlertidig lønnstilskudd' med '...hentet fra avtalen om {tiltakstypeTekst[refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype]}.'