### PR TITLE
Mentor-kvittering har to hendelselogg-knapper og ingen hvit bakgrunn

### DIFF
--- a/komponenter/src/KvitteringSide/KvitteringSideMentor/KvitteringSideMentor.tsx
+++ b/komponenter/src/KvitteringSide/KvitteringSideMentor/KvitteringSideMentor.tsx
@@ -10,6 +10,7 @@ import InformasjonFraAvtalenMentor from './InformasjonFraAvtaleMentor';
 import UtregningMentor from './UtregningMentor';
 import SummeringBoksMentor from './SummeringBoksMentor';
 import StatusEtikettMentor from './StatusEtikettMentor';
+import Boks from '~/Boks';
 
 interface Props {
     aktsomhet?: Aktsomhet;
@@ -28,41 +29,43 @@ const KvitteringSideMentor: FunctionComponent<Props> = (props: Props) => {
     const innloggetRolle = innloggetBruker?.rolle;
 
     return (
-        <VStack gap="space-16">
-            <Box>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                    <Heading level="2" size="large">
-                        Refusjon for Mentor
-                    </Heading>
-                    <StatusEtikettMentor refusjon={refusjon} />
-                </div>
-                <VerticalSpacer rem={1} />
-                <div style={{ display: 'flex', justifyContent: 'space-between', gap: '5rem' }}>
-                    <Statusmelding
-                        status={refusjon.status}
-                        vtao={true}
-                        sendtTidspunkt={refusjon.godkjentAvArbeidsgiver}
+        <Boks variant="hvit">
+            <VStack gap="space-16">
+                <Box>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                        <Heading level="2" size="large">
+                            Refusjon for Mentor
+                        </Heading>
+                        <StatusEtikettMentor refusjon={refusjon} />
+                    </div>
+                    <VerticalSpacer rem={1} />
+                    <div style={{ display: 'flex', justifyContent: 'space-between', gap: '5rem' }}>
+                        <Statusmelding
+                            status={refusjon.status}
+                            vtao={true}
+                            sendtTidspunkt={refusjon.godkjentAvArbeidsgiver}
+                        />
+                        {innloggetBruker !== undefined && innloggetBruker.rolle === 'ARBEIDSGIVER' && (
+                            <LagreSomPdfKnapp avtaleId={refusjon.id} />
+                        )}
+                    </div>
+                    <VerticalSpacer rem={1} />
+                    <InformasjonFraAvtalenMentor
+                        aktsomhet={aktsomhet}
+                        innloggetRolle={innloggetRolle}
+                        refusjonStatus={refusjon.status}
+                        refusjonsgrunnlag={refusjon.refusjonsgrunnlag}
+                        åpnetFørsteGang={refusjon.åpnetFørsteGang}
+                        settKid={settKid}
                     />
-                    {innloggetBruker !== undefined && innloggetBruker.rolle === 'ARBEIDSGIVER' && (
-                        <LagreSomPdfKnapp avtaleId={refusjon.id} />
-                    )}
-                </div>
-                <VerticalSpacer rem={1} />
-                <InformasjonFraAvtalenMentor
-                    aktsomhet={aktsomhet}
-                    innloggetRolle={innloggetRolle}
-                    refusjonStatus={refusjon.status}
-                    refusjonsgrunnlag={refusjon.refusjonsgrunnlag}
-                    åpnetFørsteGang={refusjon.åpnetFørsteGang}
-                    settKid={settKid}
+                </Box>
+                <UtregningMentor
+                    tilskuddsgrunnlag={props.refusjon.refusjonsgrunnlag.tilskuddsgrunnlag}
+                    beregning={props.refusjon.refusjonsgrunnlag.beregning}
                 />
-            </Box>
-            <UtregningMentor
-                tilskuddsgrunnlag={props.refusjon.refusjonsgrunnlag.tilskuddsgrunnlag}
-                beregning={props.refusjon.refusjonsgrunnlag.beregning}
-            />
-            <SummeringBoksMentor refusjonsgrunnlag={refusjon.refusjonsgrunnlag} />
-        </VStack>
+                <SummeringBoksMentor refusjonsgrunnlag={refusjon.refusjonsgrunnlag} />
+            </VStack>
+        </Boks>
     );
 };
 

--- a/komponenter/src/KvitteringSide/KvitteringSideMentor/KvitteringSideMentor.tsx
+++ b/komponenter/src/KvitteringSide/KvitteringSideMentor/KvitteringSideMentor.tsx
@@ -42,12 +42,10 @@ const KvitteringSideMentor: FunctionComponent<Props> = (props: Props) => {
                     <div style={{ display: 'flex', justifyContent: 'space-between', gap: '5rem' }}>
                         <Statusmelding
                             status={refusjon.status}
-                            vtao={true}
+                            automatiskInnsending={true}
                             sendtTidspunkt={refusjon.godkjentAvArbeidsgiver}
                         />
-                        {innloggetBruker !== undefined && innloggetBruker.rolle === 'ARBEIDSGIVER' && (
-                            <LagreSomPdfKnapp avtaleId={refusjon.id} />
-                        )}
+                        {innloggetBruker?.rolle === 'ARBEIDSGIVER' && <LagreSomPdfKnapp avtaleId={refusjon.id} />}
                     </div>
                     <VerticalSpacer rem={1} />
                     <InformasjonFraAvtalenMentor
@@ -60,8 +58,8 @@ const KvitteringSideMentor: FunctionComponent<Props> = (props: Props) => {
                     />
                 </Box>
                 <UtregningMentor
-                    tilskuddsgrunnlag={props.refusjon.refusjonsgrunnlag.tilskuddsgrunnlag}
-                    beregning={props.refusjon.refusjonsgrunnlag.beregning}
+                    tilskuddsgrunnlag={refusjon.refusjonsgrunnlag.tilskuddsgrunnlag}
+                    beregning={refusjon.refusjonsgrunnlag.beregning}
                 />
                 <SummeringBoksMentor refusjonsgrunnlag={refusjon.refusjonsgrunnlag} />
             </VStack>

--- a/komponenter/src/KvitteringSide/KvitteringSideVTAO/KvitteringSideVTAO.tsx
+++ b/komponenter/src/KvitteringSide/KvitteringSideVTAO/KvitteringSideVTAO.tsx
@@ -94,7 +94,11 @@ const KvitteringSideVTAO: FunctionComponent<Props> = (props: Props) => {
             </div>
             <VerticalSpacer rem={1} />
             <div style={{ display: 'flex', justifyContent: 'space-between', gap: '5rem' }}>
-                <Statusmelding status={refusjon.status} vtao={true} sendtTidspunkt={refusjon.godkjentAvArbeidsgiver} />
+                <Statusmelding
+                    status={refusjon.status}
+                    automatiskInnsending={true}
+                    sendtTidspunkt={refusjon.godkjentAvArbeidsgiver}
+                />
                 {innloggetBruker !== undefined && innloggetBruker.rolle === 'ARBEIDSGIVER' && (
                     <LagreSomPdfKnapp avtaleId={refusjon.id} />
                 )}

--- a/komponenter/src/KvitteringSide/Statusmelding.tsx
+++ b/komponenter/src/KvitteringSide/Statusmelding.tsx
@@ -6,8 +6,8 @@ import { formaterDato, NORSK_DATO_FORMAT } from '~/utils/datoUtils';
 const Statusmelding: FunctionComponent<{
     status: RefusjonStatus;
     sendtTidspunkt?: string;
-    vtao?: boolean;
-}> = ({ status, sendtTidspunkt, vtao }) => {
+    automatiskInnsending?: boolean;
+}> = ({ status, sendtTidspunkt, automatiskInnsending }) => {
     switch (status) {
         case RefusjonStatus.UTBETALING_FEILET:
             return (
@@ -33,7 +33,7 @@ const Statusmelding: FunctionComponent<{
                 </BodyShort>
             );
         case RefusjonStatus.FOR_TIDLIG:
-            if (vtao) {
+            if (automatiskInnsending) {
                 return (
                     <BodyShort size="small">
                         Refusjonskravet sendes inn automatisk når gjeldende periode er avsluttet.

--- a/saksbehandler/src/refusjon/RefusjonSide/Refusjon.tsx
+++ b/saksbehandler/src/refusjon/RefusjonSide/Refusjon.tsx
@@ -185,10 +185,6 @@ const Komponent: FunctionComponent = () => {
                     <VerticalSpacer rem={1} />
                     {tiltakstype === 'MENTOR' && (
                         <>
-                            <div className={styles.fleks}>
-                                <HendelsesLogg refusjonId={refusjonId} />
-                            </div>
-                            <VerticalSpacer rem={1} />
                             <KvitteringSideMentor
                                 aktsomhet={aktsomhet}
                                 refusjon={refusjon}


### PR DESCRIPTION
<table>
<tr><th>Før</th><th>Etter</th>
</tr>
<tr>
<td>
<img width="2286" height="1631" alt="Screenshot 2026-06-29 at 14-01-07 Tiltaksrefusjon" src="https://github.com/user-attachments/assets/eeff3a30-4094-4829-a3c2-ef886e401626" />
</td>

<td>
<img width="2286" height="1695" alt="Screenshot 2026-06-29 at 14-00-45 Tiltaksrefusjon" src="https://github.com/user-attachments/assets/10c6bd8b-0929-46e4-a8d3-70eac40a2d75" />
</td></tr>
</table>